### PR TITLE
chore(research): record the trust-gate cost replay on suggest and briefing order

### DIFF
--- a/.scars/candidates/live-local-store-makes-a-replay-look-nondeterministic.md
+++ b/.scars/candidates/live-local-store-makes-a-replay-look-nondeterministic.md
@@ -1,0 +1,44 @@
+---
+id: 0
+type: landmine
+title: A replay that reads ~/.daimon/checkpoints is not reproducible — other sessions append mid-run and it reads as runner nondeterminism
+severity: medium
+confidence: 0.95
+created: 2026-09-12
+authors: ["claude-code"]
+anchors:
+  - path: research/experiments/
+expires:
+  condition: "an experiment harness exists that snapshots and fingerprints its substrate by default"
+  review_after: 2027-03-01
+evidence:
+  - note: "#976 replay — pass A and pass B were byte-identical, pass C twenty seconds later differed in 485 lines; the cause was four checkpoints written into ~/.daimon/checkpoints by other sessions between the passes, not the runner"
+status: candidate
+---
+
+The bench substrate under `benchmark/.work/` is frozen, so the #754 replay's
+copy-on-read discipline is enough for it. The local checkpoint store is not.
+`~/.daimon/checkpoints` is the machine's live store: every other agent session,
+every `daimon ruling`, every SessionEnd capture appends to it while your replay
+is running. Two passes minutes apart read two different corpora.
+
+This does not look like a moving substrate. It looks like a nondeterministic
+runner, and it sends you hunting for unsorted iteration or a hash seed inside
+code that is in fact perfectly deterministic. In #976 the first two passes were
+byte-identical, which made the third pass's 485-line diff read as a genuine
+instability; the actual cause was a `latest.json` rewrite and a new
+`refutations.jsonl` row written by unrelated sessions in the gap.
+
+Copy-on-read does not solve it either. Copying the store into scratch protects
+the ORIGINAL, which is a different problem; the copy still captures whatever
+the store happened to hold at copy time.
+
+What a future editor must do: freeze the local store into a snapshot ONCE,
+point the runner at the snapshot for every pass, and record a fingerprint of
+the files actually read in the committed output. Then a later re-run can tell
+"the code changed" from "the store moved" instead of guessing. `#976`'s
+`fingerprint_store` and the `inputs` block in its `measurements.json` are the
+shape. Also beware the mirror trap when auditing the store afterwards: a
+before/after `stat` diff over the live store shows writes you did not make, so
+take the two snapshots as close around the run as possible or you will spend
+the audit proving a clean runner dirty.

--- a/.scars/candidates/trust-reaches-the-briefing-twice-and-the-second-path-has-the-opposite-sign.md
+++ b/.scars/candidates/trust-reaches-the-briefing-twice-and-the-second-path-has-the-opposite-sign.md
@@ -1,0 +1,45 @@
+---
+id: 0
+type: landmine
+title: Trust reaches the rendered briefing through TWO paths, and the truncation exemption pushes the opposite way from the weight lid
+severity: medium
+confidence: 0.9
+created: 2026-09-12
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/briefing.py
+  - path: plugin/daimon_briefing/scoring.py
+evidence:
+  - note: "#976 replay — 320 of 6600 briefing comparisons differ between a gated and an ungated arm; one of them has zero lid-biting flips and is caused entirely by the stage-1 verbatim truncation exemption"
+expires:
+  condition: "render_plain stage 1 stops exempting verbatim items, or the exemption stops depending on the trust field"
+  review_after: 2027-03-01
+status: candidate
+---
+
+Everyone reasons about the #408 trust ceiling as THE way a trust class reaches
+a read surface: `scoring.effective_weight` applies the lid last, so a lower
+class ranks lower. That is true and it is not the whole mechanism for the
+briefing.
+
+`render_plain` stage 1 shortens oversized items in place and exempts verbatim
+ones, because #23 froze verbatim text and a render that rewrites it breaks that
+guarantee. So an item's trust class also decides whether its text costs the
+budget its full length or `_ITEM_TRUNCATE_CHARS`. Downgrading an item to
+inferred makes it truncatable, which FREES budget, which lets stage 2 keep an
+item it would otherwise have dropped. The weight lid pushes a downgraded item
+down; the truncation exemption pushes other items up. Same field, opposite
+sign, different sections.
+
+Measured, not reasoned: in the #976 replay one local checkpoint at the 30-day
+horizon rendered identical section ORDER in both arms and still dropped a
+different number of uncertainties (4 gated, 5 ungated). No flipped item in it
+cleared the 0.63 soft-clip knee, so the weight path explains nothing. One
+610-character inferred decision did it alone: truncated to 400 while inferred,
+exempt once flipped to verbatim, 52 tokens heavier, one more item evicted.
+
+What a future editor must do: when you measure or reason about "what the trust
+gate costs the briefing", do not stop at `effective_weight`. Any change to
+`_ITEM_TRUNCATE_CHARS`, to `truncate_preserving_sections`, or to the stage-1
+exemption test `i.get("trust") == "verbatim"` is a change to how trust affects
+which items survive the budget, and it will not show up in any ordering test.

--- a/research/experiments/trust-gate-cost-976/measurements.json
+++ b/research/experiments/trust-gate-cost-976/measurements.json
@@ -1610,7 +1610,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-1e3827"
+    "3d0e173f130a3f29"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1638,8 +1638,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1613ed": 1,
-       "s-1e3827": -1
+       "3d0e173f130a3f29": -1,
+       "bff346803e39cd1a": 1
       }
      }
     }
@@ -1653,7 +1653,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-768ef5"
+    "ea96d6bed7455462"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1681,8 +1681,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-768ef5": -1,
-       "o-907d3a": 1
+       "ea96d6bed7455462": -1,
+       "f54da6879138c4bd": 1
       }
      }
     }
@@ -1696,8 +1696,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "h:c4943862a3d9",
-    "o-38c93b"
+    "1bc13f74327f1204",
+    "96990958402e0aa5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1725,8 +1725,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-38c93b": -1,
-       "o-d36d88": 1
+       "1bc13f74327f1204": -1,
+       "63513df48a77aea2": 1
       }
      }
     }
@@ -1740,7 +1740,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-38c93b"
+    "1bc13f74327f1204"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1768,8 +1768,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-38c93b": -1,
-       "o-d36d88": 1
+       "1bc13f74327f1204": -1,
+       "63513df48a77aea2": 1
       }
      }
     }
@@ -1783,7 +1783,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-24eea5"
+    "98e8183af51128c7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1811,8 +1811,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-24eea5": -1,
-       "s-39c9f0": 1
+       "37b015cc195fd919": 1,
+       "98e8183af51128c7": -1
       }
      }
     }
@@ -1826,9 +1826,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-191fc9",
-    "s-587119",
-    "s-a0c80b"
+    "070cc9e007a1abc4",
+    "2b47d371d28c3d9b",
+    "b33b8065d6a5669a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1856,10 +1856,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-587119": -2,
-       "s-5aee02": 2,
-       "s-a0c80b": -2,
-       "s-cf2025": 2
+       "2b47d371d28c3d9b": -2,
+       "7396b0cb258e91d5": 2,
+       "a1aad761de0183c5": 2,
+       "b33b8065d6a5669a": -2
       }
      }
     }
@@ -1873,7 +1873,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-251a73"
+    "427118b80ca427b1"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1901,9 +1901,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1a0cbc": 1,
-       "s-251a73": -2,
-       "s-b67e50": 1
+       "04cf47443f48daf3": 1,
+       "427118b80ca427b1": -2,
+       "b4c5d2fe1738a24d": 1
       }
      }
     }
@@ -1917,8 +1917,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-de3b03",
-    "s-4c1f6b"
+    "1a5973ee869d02c6",
+    "f931b81e90ecbb93"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1946,8 +1946,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1d617c": 1,
-       "s-4c1f6b": -1
+       "6471926ab3ec86fa": 1,
+       "f931b81e90ecbb93": -1
       }
      }
     }
@@ -1961,8 +1961,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-8309d3",
-    "s-e5d3eb"
+    "6512dbb5c6cb2723",
+    "d7acbe7c47f4b03f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -1990,8 +1990,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-b032c6": 1,
-       "s-e5d3eb": -1
+       "4140dd8833537f96": 1,
+       "d7acbe7c47f4b03f": -1
       }
      }
     }
@@ -2005,10 +2005,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-2e6a07",
-    "r-6a040b",
-    "r-8bbb22",
-    "s-cef9dd"
+    "a438b3fd53af2b41",
+    "b7921afa5053af71",
+    "ccb8559a63c94dc4",
+    "e087252164646a39"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2036,9 +2036,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-584d35": 1,
-       "s-cef9dd": -2,
-       "s-e54430": 1
+       "067988309da80c4a": 1,
+       "4e9d7c1dbe0af14a": 1,
+       "a438b3fd53af2b41": -2
       }
      }
     }
@@ -2052,7 +2052,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-f13eae"
+    "cd6878ab8544a43a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2080,12 +2080,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5c58b4": 1,
-       "s-6d85a8": 1,
-       "s-d4f167": 1,
-       "s-dd60dc": 1,
-       "s-f13eae": -5,
-       "s-f85d14": 1
+       "3dfe768d57dd3e6b": 1,
+       "46ea5cecb877fc92": 1,
+       "856776decce1be03": 1,
+       "a88fa649b72d7ca6": 1,
+       "cd6878ab8544a43a": -5,
+       "ebd0efdf2099040a": 1
       }
      }
     }
@@ -2099,7 +2099,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-ab070c"
+    "d242e77971c5f0db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2127,8 +2127,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-939c11": 1,
-       "s-ab070c": -1
+       "0f08724ed0e83521": 1,
+       "d242e77971c5f0db": -1
       }
      }
     }
@@ -2142,7 +2142,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-6d0b8f"
+    "95b896f452c10d7c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2170,8 +2170,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6d0b8f": -1,
-       "s-e25065": 1
+       "95b896f452c10d7c": -1,
+       "aecb1513758728fb": 1
       }
      }
     }
@@ -2185,7 +2185,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-824fdf"
+    "34f806f0bb2855ea"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2213,10 +2213,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3a1eac": 1,
-       "s-469143": 1,
-       "s-824fdf": -3,
-       "s-b6b0e8": 1
+       "1b606c64584b5e51": 1,
+       "34f806f0bb2855ea": -3,
+       "d7be4304a26e892c": 1,
+       "eb6150829a1c3087": 1
       }
      }
     }
@@ -2230,7 +2230,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-e935a1"
+    "8eba9aee6e0f9e5a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2258,9 +2258,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-108c24": 1,
-       "s-b2eea7": 1,
-       "s-e935a1": -2
+       "424b36f9784f2f19": 1,
+       "8eba9aee6e0f9e5a": -2,
+       "c7ac0deab49b717a": 1
       }
      }
     }
@@ -2274,8 +2274,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-845fdb",
-    "s-0eb375"
+    "46a7533f3b8556c4",
+    "a3f5392ec9451802"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2303,9 +2303,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-47876a": 1,
-       "o-845fdb": -2,
-       "o-b1fbd1": 1
+       "36995e2332db4663": 1,
+       "431552117081115e": 1,
+       "a3f5392ec9451802": -2
       }
      }
     }
@@ -2319,8 +2319,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "h:328cece78696",
-    "s-c233ac"
+    "3caebb7ff9be7364",
+    "a7f79c081e9b6efb"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2348,8 +2348,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-ae8828": 1,
-       "s-c233ac": -1
+       "31085bdc222d243e": 1,
+       "a7f79c081e9b6efb": -1
       }
      }
     }
@@ -2363,8 +2363,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "h:ce0d3ced273f",
-    "s-1738fd"
+    "43749713800578fc",
+    "4e6f54e5dbe9041a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2392,8 +2392,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1738fd": -1,
-       "s-5d32f7": 1
+       "43749713800578fc": -1,
+       "597179aaadf86e9e": 1
       }
      }
     }
@@ -2407,7 +2407,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-95dce9"
+    "e15cb4d3985e9a18"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2435,8 +2435,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-95dce9": -1,
-       "o-eb060b": 1
+       "a259015ff28770ce": 1,
+       "e15cb4d3985e9a18": -1
       }
      }
     }
@@ -2450,7 +2450,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-95dce9"
+    "e15cb4d3985e9a18"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2478,8 +2478,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-95dce9": -1,
-       "o-eb060b": 1
+       "a259015ff28770ce": 1,
+       "e15cb4d3985e9a18": -1
       }
      }
     }
@@ -2493,9 +2493,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "h:08327ea43411",
-    "r-d8c96c",
-    "s-477d94"
+    "2f8641bd0990700c",
+    "aa8c81f928ddb16f",
+    "e9ccd78d6a8e2be5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2523,8 +2523,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-477d94": -1,
-       "s-881cb2": 1
+       "2f8641bd0990700c": -1,
+       "9ca38e9a4bb5e95c": 1
       }
      }
     }
@@ -2538,8 +2538,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-23d75e",
-    "r-ce3c73"
+    "4bdbeafeb118de2f",
+    "7b54364d8a9aacdf"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2567,10 +2567,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-23d75e": -3,
-       "o-8defc2": 1,
-       "o-8e35a9": 1,
-       "o-b52e53": 1
+       "2641f8b71ccb5188": 1,
+       "5bbdc70a551ff34c": 1,
+       "7b54364d8a9aacdf": -3,
+       "a78f2e0877927516": 1
       }
      }
     }
@@ -2584,7 +2584,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-23d75e"
+    "7b54364d8a9aacdf"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2612,8 +2612,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-23d75e": -1,
-       "o-8defc2": 1
+       "7b54364d8a9aacdf": -1,
+       "a78f2e0877927516": 1
       }
      }
     }
@@ -2627,8 +2627,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-2e77c7",
-    "o-ef1436"
+    "211bea9a8b180840",
+    "3f726a9066050c45"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2656,9 +2656,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2e77c7": -1,
-       "o-aa11b4": 2,
-       "o-ef1436": -1
+       "211bea9a8b180840": -1,
+       "3f726a9066050c45": -1,
+       "8f4f9a13c58378ee": 2
       }
      }
     }
@@ -2672,8 +2672,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-2e77c7",
-    "o-ef1436"
+    "211bea9a8b180840",
+    "3f726a9066050c45"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2701,8 +2701,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2e77c7": -1,
-       "o-aa11b4": 1
+       "3f726a9066050c45": -1,
+       "8f4f9a13c58378ee": 1
       }
      }
     }
@@ -2716,8 +2716,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "h:64fa4f583b5b",
-    "s-35ae27"
+    "a673bffa30be6dad",
+    "bfd110a585323f82"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2745,8 +2745,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-35ae27": -1,
-       "s-cac9f1": 1
+       "a673bffa30be6dad": -1,
+       "f9a6a5da2cf61e7b": 1
       }
      }
     }
@@ -2760,7 +2760,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-947ab0"
+    "e7472e6394293d09"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2788,8 +2788,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-621795": 1,
-       "s-947ab0": -1
+       "1142e176f0718bdc": 1,
+       "e7472e6394293d09": -1
       }
      }
     }
@@ -2803,10 +2803,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "h:aca0a6921b61",
-    "o-004435",
-    "o-1a54bf",
-    "s-50c82a"
+    "30a407fa5087de95",
+    "4e88a00b5f4a6640",
+    "9abe319ea96581f9",
+    "fe5a895cd3c57ff5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2834,9 +2834,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-004435": -1,
-       "o-08b46d": 2,
-       "o-1a54bf": -1
+       "30a407fa5087de95": -1,
+       "fae33880ab3f976c": 2,
+       "fe5a895cd3c57ff5": -1
       }
      }
     },
@@ -2852,8 +2852,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-17e0a8": 1,
-       "s-50c82a": -1
+       "4e88a00b5f4a6640": -1,
+       "6fd06361f634f799": 1
       }
      }
     }
@@ -2867,8 +2867,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-461312",
-    "s-57abe1"
+    "31111566ef65309b",
+    "b692bc4893167538"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2896,9 +2896,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-430a3a": 1,
-       "s-57abe1": -2,
-       "s-7ca42b": 1
+       "252ca766c418086c": 1,
+       "31111566ef65309b": -2,
+       "ea6f7043185393e2": 1
       }
      }
     }
@@ -2912,8 +2912,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-9976fb",
-    "s-70e5f2"
+    "ba4709ae00355a39",
+    "c9d7f1924d1d994e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2941,8 +2941,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3e9745": 1,
-       "s-70e5f2": -1
+       "ba4709ae00355a39": -1,
+       "bb5a08f213de0119": 1
       }
      }
     }
@@ -2956,8 +2956,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-b8a3a3",
-    "s-6c08e3"
+    "1c5bf92a76148de3",
+    "644eb07ca7755868"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -2985,8 +2985,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6637d5": 1,
-       "s-6c08e3": -1
+       "1c5bf92a76148de3": -1,
+       "d902bd86aa5fab58": 1
       }
      }
     }
@@ -3000,7 +3000,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-144101"
+    "e6ae2c9577ca7678"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3028,9 +3028,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-144101": -2,
-       "s-46ef7f": 1,
-       "s-bb9999": 1
+       "00fa343f4e2e71a9": 1,
+       "2af78776565dbc88": 1,
+       "e6ae2c9577ca7678": -2
       }
      }
     }
@@ -3044,7 +3044,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-ec9c78"
+    "b543f104c4c1b9af"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3072,9 +3072,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-55a5f0": 1,
-       "s-879b2e": 1,
-       "s-ec9c78": -2
+       "0327922224c922be": 1,
+       "b543f104c4c1b9af": -2,
+       "f64df5af600569b8": 1
       }
      }
     }
@@ -3088,11 +3088,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "h:df492a18566d",
-    "o-4d52cc",
-    "s-5d2f97",
-    "s-631e49",
-    "s-7f1b1f"
+    "4cb386eacaf2d0bd",
+    "50272a5e36bd88ad",
+    "68d2f1273ab18501",
+    "ba47b72c27254b67",
+    "bcd372f9dd1a2960"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3120,8 +3120,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-3de466": 1,
-       "o-4d52cc": -1
+       "35736cfb9ef6d1d2": 1,
+       "bcd372f9dd1a2960": -1
       }
      }
     },
@@ -3137,10 +3137,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5d2f97": -1,
-       "s-631e49": -1,
-       "s-7f1b1f": -1,
-       "s-a8f215": 3
+       "4cb386eacaf2d0bd": -1,
+       "50272a5e36bd88ad": -1,
+       "ba47b72c27254b67": -1,
+       "eb9e497373a2d794": 3
       }
      }
     }
@@ -3154,12 +3154,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "o-7ad1eb",
-    "o-a1538e",
-    "r-1f114b",
-    "r-5a51f0",
-    "r-738951",
-    "s-9fc158"
+    "2290ac8bdbfeace6",
+    "29fe61dad196be2c",
+    "2d0aa333f220ae03",
+    "7708290862dfb754",
+    "c74142929b99fa91",
+    "df2ea6d76c645f15"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3187,9 +3187,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0bf78b": 2,
-       "o-7ad1eb": -1,
-       "o-a1538e": -1
+       "41f1e99045d644ef": 2,
+       "c74142929b99fa91": -1,
+       "df2ea6d76c645f15": -1
       }
      }
     }
@@ -3203,7 +3203,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-7283c8"
+    "92d4d852f7576f99"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3231,13 +3231,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2bec08": 1,
-       "s-4620a8": 1,
-       "s-474a02": 1,
-       "s-6ad1e5": 1,
-       "s-7283c8": -6,
-       "s-b53916": 1,
-       "s-f1354e": 1
+       "00e2be63cf4e172f": 1,
+       "1008844833200a4d": 1,
+       "147f3b3dadd74533": 1,
+       "56c7c6b958f7aed8": 1,
+       "91999300d1cc9ace": 1,
+       "92d4d852f7576f99": -6,
+       "995001b842e5955b": 1
       }
      }
     }
@@ -3251,8 +3251,8 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-69a1e5",
-    "s-2b3076"
+    "0b89f8e9aa423fdb",
+    "6844bc2164c8692b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3280,9 +3280,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2b3076": -2,
-       "s-48b495": 1,
-       "s-4f98b9": 1
+       "0b89f8e9aa423fdb": -2,
+       "0e80c6eacda3cc7d": 1,
+       "26118dbb74a2868d": 1
       }
      }
     }
@@ -3296,8 +3296,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-692a64",
-    "s-adc7cd"
+    "3452646ccefbd0a7",
+    "fdedb68df9f66d8d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3325,10 +3325,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1350d1": 2,
-       "s-692a64": -2,
-       "s-9bebfd": 1,
-       "s-adc7cd": -1
+       "33d1294fbc58b4c3": 1,
+       "3452646ccefbd0a7": -1,
+       "4608dfde2934abd8": 2,
+       "fdedb68df9f66d8d": -2
       }
      }
     }
@@ -3342,8 +3342,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-cdfd21",
-    "s-48ed00"
+    "3b70ce36b98c159f",
+    "de25c6d8d3639ae2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3371,11 +3371,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-48ed00": -4,
-       "s-561f30": 1,
-       "s-5825a2": 1,
-       "s-af7fdf": 1,
-       "s-bdc1b2": 1
+       "0615928345c127cf": 1,
+       "3b70ce36b98c159f": -4,
+       "3c382b4e4b37c057": 1,
+       "40b2d5af2d6148cb": 1,
+       "abd307fa94a40998": 1
       }
      }
     }
@@ -3389,8 +3389,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-0fb1e8",
-    "s-d202b6"
+    "55616806dc1683b3",
+    "e6d2ca030572f59e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3418,11 +3418,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-9ab014": 1,
-       "s-b5f904": 1,
-       "s-c6c9b3": 1,
-       "s-c83a70": 1,
-       "s-d202b6": -4
+       "3614c7b52ed9adab": 1,
+       "b671d7a0f6aec3ac": 1,
+       "c3d9bbdde9c39849": 1,
+       "e6d2ca030572f59e": -4,
+       "fea3eb69991b2289": 1
       }
      }
     }
@@ -3436,7 +3436,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-fa41fa"
+    "1d00079bf024b024"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3464,10 +3464,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-58bf67": 1,
-       "s-c7dfd5": 1,
-       "s-ea152c": 1,
-       "s-fa41fa": -3
+       "1d00079bf024b024": -3,
+       "936e3e335d86e96c": 1,
+       "a341942ed15bc89e": 1,
+       "f9f6c37ad7cf0148": 1
       }
      }
     }
@@ -3481,7 +3481,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-a2a427"
+    "383e9a45301e2a3e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3509,8 +3509,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-77c741": 1,
-       "s-a2a427": -1
+       "383e9a45301e2a3e": -1,
+       "7d215ad3a473f465": 1
       }
      }
     }
@@ -3524,7 +3524,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-e935a1"
+    "8eba9aee6e0f9e5a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3552,9 +3552,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-108c24": 1,
-       "s-b2eea7": 1,
-       "s-e935a1": -2
+       "424b36f9784f2f19": 1,
+       "8eba9aee6e0f9e5a": -2,
+       "c7ac0deab49b717a": 1
       }
      }
     }
@@ -3568,7 +3568,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-d777b4"
+    "ef587559ec8d2179"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3596,9 +3596,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-63d6db": 1,
-       "s-d777b4": -2,
-       "s-ddf142": 1
+       "eb7a9a40fcebf38f": 1,
+       "ef587559ec8d2179": -2,
+       "f3760963815b99d7": 1
       }
      }
     }
@@ -3612,8 +3612,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-41a7ae",
-    "s-d11293"
+    "c9dc1199d40588c7",
+    "e858e974f6f096fb"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3641,9 +3641,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-41a7ae": -1,
-       "s-7a5e46": 2,
-       "s-d11293": -1
+       "5851ce58a135f3bb": 2,
+       "c9dc1199d40588c7": -1,
+       "e858e974f6f096fb": -1
       }
      }
     }
@@ -3657,8 +3657,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-41a7ae",
-    "s-d11293"
+    "c9dc1199d40588c7",
+    "e858e974f6f096fb"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3686,9 +3686,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-41a7ae": -1,
-       "s-7a5e46": 2,
-       "s-d11293": -1
+       "5851ce58a135f3bb": 2,
+       "c9dc1199d40588c7": -1,
+       "e858e974f6f096fb": -1
       }
      }
     }
@@ -3702,7 +3702,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-3477e2"
+    "560f905f234459da"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3730,9 +3730,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3477e2": -2,
-       "s-3e6789": 1,
-       "s-c3e0ce": 1
+       "560f905f234459da": -2,
+       "bdcd2360660eb66b": 1,
+       "ceb3df63dbb84827": 1
       }
      }
     }
@@ -3746,7 +3746,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-c92929"
+    "39a8cbe0c4179004"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3774,10 +3774,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-b22377": 1,
-       "s-c92929": -3,
-       "s-d6067e": 1,
-       "s-f50d03": 1
+       "39a8cbe0c4179004": -3,
+       "53fbcc559f3b846e": 1,
+       "a89c4b5a5739f06d": 1,
+       "e6f0150b7ab905c0": 1
       }
      }
     }
@@ -3791,7 +3791,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-6d0b8f"
+    "95b896f452c10d7c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3819,8 +3819,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6d0b8f": -1,
-       "s-e25065": 1
+       "95b896f452c10d7c": -1,
+       "aecb1513758728fb": 1
       }
      }
     }
@@ -3834,7 +3834,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-9c6795"
+    "d25db4f343e5e0d0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3862,9 +3862,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-877b3a": 1,
-       "s-9c6795": -2,
-       "s-f077bc": 1
+       "41cdd755f74f38a7": 1,
+       "d25db4f343e5e0d0": -2,
+       "e41c71b344b29aa3": 1
       }
      }
     }
@@ -3878,7 +3878,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-24eea5"
+    "98e8183af51128c7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3906,8 +3906,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-24eea5": -1,
-       "s-39c9f0": 1
+       "37b015cc195fd919": 1,
+       "98e8183af51128c7": -1
       }
      }
     }
@@ -3921,7 +3921,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-f4b60c"
+    "939770ccd11f0325"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3949,8 +3949,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-76f39e": 1,
-       "s-f4b60c": -1
+       "34c6d5252c5ef1b9": 1,
+       "939770ccd11f0325": -1
       }
      }
     }
@@ -3964,7 +3964,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-67462e"
+    "14da60d7c3d70946"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -3989,10 +3989,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-d6417a"
+       "78ad863fef7aa882"
       ],
       "only_ungated": [
-       "s-67462e"
+       "14da60d7c3d70946"
       ]
      },
      "rank_diff": {
@@ -4000,11 +4000,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3315b1": 1,
-       "s-613b85": 1,
-       "s-67462e": -4,
-       "s-ba0417": 1,
-       "s-d6417a": 1
+       "14da60d7c3d70946": -4,
+       "321d26d8c1f6c10d": 1,
+       "5f56aca239710c0a": 1,
+       "78ad863fef7aa882": 1,
+       "c0e9e99e46665d87": 1
       }
      }
     }
@@ -4018,8 +4018,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-2d669b",
-    "s-38885d"
+    "026d988d0ad4f68c",
+    "d89b75771afb230e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4047,14 +4047,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-112f9a": 2,
-       "s-187ccc": 2,
-       "s-2d669b": -6,
-       "s-38885d": -4,
-       "s-97cd4f": 1,
-       "s-a6815b": 2,
-       "s-c578e6": 1,
-       "s-d32b71": 2
+       "026d988d0ad4f68c": -4,
+       "10cb997e09e8606c": 2,
+       "375e63dc38445519": 2,
+       "7c3b9c2b00d41186": 1,
+       "9a03930bb768e87b": 1,
+       "bfda4346c00443c3": 2,
+       "d89b75771afb230e": -6,
+       "ecdc1266205e1947": 2
       }
      }
     }
@@ -4068,9 +4068,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "h:bde37e2c9092",
-    "r-292014",
-    "s-902171"
+    "478f207ffa9d13fc",
+    "53f652bb726bf0db",
+    "6371d10c7b15f6c6"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4098,9 +4098,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-226b1f": 1,
-       "s-902171": -2,
-       "s-9ad651": 1
+       "478f207ffa9d13fc": -2,
+       "610099f951c97c32": 1,
+       "c349211b67bc9c08": 1
       }
      }
     }
@@ -4114,9 +4114,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "s-1f5d50",
-    "s-43b611",
-    "s-7ef59c"
+    "6d28356a534074b3",
+    "9d9f3598fb698d1d",
+    "c5af8d61032d5dcc"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4144,10 +4144,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1f5d50": -1,
-       "s-2550ff": 3,
-       "s-43b611": -1,
-       "s-7ef59c": -1
+       "6d28356a534074b3": -1,
+       "9d9f3598fb698d1d": -1,
+       "c5af8d61032d5dcc": -1,
+       "fd9af93eacedb195": 3
       }
      }
     }
@@ -4161,7 +4161,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-6cf978"
+    "ff89534e487b7899"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4189,8 +4189,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6cf978": -1,
-       "s-f04962": 1
+       "a106de639ff9b187": 1,
+       "ff89534e487b7899": -1
       }
      }
     }
@@ -4204,7 +4204,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-32302b"
+    "1932a3900d335757"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4232,8 +4232,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-32302b": -1,
-       "s-e72eb4": 1
+       "018696320740e095": 1,
+       "1932a3900d335757": -1
       }
      }
     }
@@ -4247,7 +4247,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-32302b"
+    "1932a3900d335757"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4275,8 +4275,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-32302b": -1,
-       "s-e72eb4": 1
+       "018696320740e095": 1,
+       "1932a3900d335757": -1
       }
      }
     }
@@ -4290,7 +4290,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-32302b"
+    "1932a3900d335757"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4318,8 +4318,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-32302b": -1,
-       "s-e72eb4": 1
+       "018696320740e095": 1,
+       "1932a3900d335757": -1
       }
      }
     }
@@ -4333,8 +4333,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-461312",
-    "s-57abe1"
+    "31111566ef65309b",
+    "b692bc4893167538"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4362,9 +4362,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-430a3a": 1,
-       "s-57abe1": -2,
-       "s-7ca42b": 1
+       "252ca766c418086c": 1,
+       "31111566ef65309b": -2,
+       "ea6f7043185393e2": 1
       }
      }
     }
@@ -4378,8 +4378,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-fa78e5",
-    "s-3bf1d9"
+    "42540fc1084719cf",
+    "4e0f9889080c9040"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4407,11 +4407,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-20c453": 1,
-       "s-3bf1d9": -4,
-       "s-52731c": 1,
-       "s-a115ef": 1,
-       "s-d91b7c": 1
+       "164f2b450b658529": 1,
+       "42540fc1084719cf": -4,
+       "8dd97dacc75a7238": 1,
+       "f554f2ccc2f73736": 1,
+       "f8a70887ebdae5da": 1
       }
      }
     }
@@ -4425,7 +4425,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-bb40ce"
+    "1ef3d29d5c5ba059"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4453,9 +4453,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-19a066": 1,
-       "s-bb40ce": -2,
-       "s-e8c3b4": 1
+       "1ef3d29d5c5ba059": -2,
+       "384d261d2d14746b": 1,
+       "d397bc57311c1469": 1
       }
      }
     }
@@ -4469,9 +4469,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-92883c",
-    "r-397b7c",
-    "s-21f8e0"
+    "1bf6d1a9cd3217bf",
+    "2f816ddf801ff7be",
+    "61c67737ffdaa57f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4499,8 +4499,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-7cd552": 1,
-       "o-92883c": -1
+       "2f816ddf801ff7be": -1,
+       "c2276653c2159e78": 1
       }
      }
     },
@@ -4516,9 +4516,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-21f8e0": -2,
-       "s-64b322": 1,
-       "s-dcd61a": 1
+       "1bf6d1a9cd3217bf": -2,
+       "6e52f0e43bd1bdff": 1,
+       "f82f3e08f9721bb8": 1
       }
      }
     }
@@ -4532,8 +4532,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-c5d633",
-    "s-009473"
+    "1317127711119205",
+    "5a05fe90c6c185ed"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4561,9 +4561,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-009473": -2,
-       "s-e34bf3": 1,
-       "s-e7d283": 1
+       "1317127711119205": -2,
+       "6de12f7308a5f4c1": 1,
+       "bafa76ea389c7af4": 1
       }
      }
     }
@@ -4577,7 +4577,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-868dc6"
+    "72ff0cc46b908687"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4605,9 +4605,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-109ad4": 1,
-       "s-868dc6": -2,
-       "s-e45c1a": 1
+       "202b0729a606e593": 1,
+       "72ff0cc46b908687": -2,
+       "ee7ce6a9eae90593": 1
       }
      }
     }
@@ -4621,8 +4621,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "h:56637375da27",
-    "o-b6f4ac"
+    "4df74cd34bdac91e",
+    "9b5147ddbdf8dba1"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4650,8 +4650,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-b6f4ac": -1,
-       "o-d9115d": 1
+       "4df74cd34bdac91e": -1,
+       "4f28a9cc270c8170": 1
       }
      }
     }
@@ -4665,7 +4665,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-b6f4ac"
+    "4df74cd34bdac91e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4693,8 +4693,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-b6f4ac": -1,
-       "o-d9115d": 1
+       "4df74cd34bdac91e": -1,
+       "4f28a9cc270c8170": 1
       }
      }
     }
@@ -4708,7 +4708,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-5b80d0"
+    "0324a0bfce4f4e9b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4736,8 +4736,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5b80d0": -1,
-       "s-a10142": 1
+       "0324a0bfce4f4e9b": -1,
+       "9c55364adb0e1621": 1
       }
      }
     }
@@ -4751,14 +4751,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "o-5a7ac6",
-    "r-186edd",
-    "r-982fb3",
-    "r-c0ac38",
-    "r-ec097d",
-    "r-f7028e",
-    "s-6da42a",
-    "s-7512e4"
+    "0e5bde615f1b9f1b",
+    "130b5f97ec61a3a5",
+    "22f77234405c7a02",
+    "720c9e67a5afd232",
+    "7eb21726e779274a",
+    "b3fa05e9ecc32195",
+    "b66d3fb007f204c1",
+    "ce25a015165df0f5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4786,10 +4786,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6da42a": -1,
-       "s-7512e4": -2,
-       "s-d60767": 1,
-       "s-f63a94": 2
+       "0e5bde615f1b9f1b": -2,
+       "130b5f97ec61a3a5": -1,
+       "98b322395a9c7d99": 1,
+       "a2010c953053aba8": 2
       }
      }
     }
@@ -4803,7 +4803,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-eee3b8"
+    "8396457d97202c27"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4831,9 +4831,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-03953a": 1,
-       "s-79571b": 1,
-       "s-eee3b8": -2
+       "3ca959696c8d711e": 1,
+       "4e399929b7ad582b": 1,
+       "8396457d97202c27": -2
       }
      }
     }
@@ -4847,9 +4847,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-4cb1d0",
-    "s-26e72f",
-    "s-b6778c"
+    "4071dbdaa5259260",
+    "7b89037b245874ce",
+    "d5d426ca1c572655"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4877,9 +4877,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-26e72f": -2,
-       "s-5a7489": 1,
-       "s-ada4ab": 1
+       "4071dbdaa5259260": -2,
+       "5e7e22a88286ad10": 1,
+       "e073d71dbbd4fe85": 1
       }
      }
     }
@@ -4893,8 +4893,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-4f94f7",
-    "s-b500b1"
+    "a008ebb60fc629f5",
+    "c4f2d0cbe91a337d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4922,9 +4922,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-8c91de": 1,
-       "s-a61d93": 1,
-       "s-b500b1": -2
+       "4481e89cec73a210": 1,
+       "6534ee6cf289612a": 1,
+       "c4f2d0cbe91a337d": -2
       }
      }
     }
@@ -4938,7 +4938,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-0cf82d"
+    "0f35013119d1b9c8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -4966,9 +4966,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0cf82d": -2,
-       "o-45b1a3": 1,
-       "o-9e62c6": 1
+       "0f35013119d1b9c8": -2,
+       "2ba002c4db2aebe8": 1,
+       "fb435b854fbe6a63": 1
       }
      }
     }
@@ -4982,12 +4982,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "h:67c25293982d",
-    "r-2f6ac7",
-    "r-604e19",
-    "r-6a6f82",
-    "r-e6f3ab",
-    "s-991a07"
+    "1aa8ccc7e830e2f7",
+    "2fc00b0a60d4eb9a",
+    "5d1e9ab9d1f81cf9",
+    "8090541baaf06da4",
+    "b93aae8e4e4dbfcc",
+    "f33ee3947fae9997"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5015,9 +5015,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-29bd0e": 1,
-       "s-991a07": -2,
-       "s-ebf4f3": 1
+       "39b0c581cfe2d4bc": 1,
+       "50cefb9c04992238": 1,
+       "5d1e9ab9d1f81cf9": -2
       }
      }
     }
@@ -5031,8 +5031,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-fef9db",
-    "s-15fcfb"
+    "445e733607e885e8",
+    "68af318dbd8f8238"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5060,9 +5060,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-15fcfb": -2,
-       "s-5f038e": 1,
-       "s-a372ca": 1
+       "43ca5a9ccdbec45c": 1,
+       "445e733607e885e8": -2,
+       "c76481317237559d": 1
       }
      }
     }
@@ -5076,8 +5076,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-0b5a6d",
-    "s-e31a15"
+    "55e197288f56725a",
+    "fce0626bd99db362"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5105,12 +5105,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0b5a6d": -1,
-       "s-80d8a3": 1,
-       "s-85c260": 1,
-       "s-948ee6": 1,
-       "s-e31a15": -4,
-       "s-eedc4e": 2
+       "2eb9d4233e317962": 1,
+       "55e197288f56725a": -4,
+       "624592d3ab72171b": 2,
+       "a03fa94f0a2d6c35": 1,
+       "e672494108de773a": 1,
+       "fce0626bd99db362": -1
       }
      }
     }
@@ -5124,7 +5124,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-ab070c"
+    "d242e77971c5f0db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5152,8 +5152,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-939c11": 1,
-       "s-ab070c": -1
+       "0f08724ed0e83521": 1,
+       "d242e77971c5f0db": -1
       }
      }
     }
@@ -5167,7 +5167,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-b2e83f"
+    "c0ba48b984f08690"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5195,8 +5195,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5270ae": 1,
-       "s-b2e83f": -1
+       "9315c789beb02659": 1,
+       "c0ba48b984f08690": -1
       }
      }
     }
@@ -5210,8 +5210,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-9ec3e5",
-    "r-ec9dd4"
+    "25e69bf12f4186c3",
+    "5c61c4624e66768c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5239,8 +5239,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-760ff3": 1,
-       "o-9ec3e5": -1
+       "25e69bf12f4186c3": -1,
+       "d0b705f584db32df": 1
       }
      }
     }
@@ -5254,12 +5254,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "h:cad8b926a522",
-    "s-2a0377",
-    "s-2c53a0",
-    "s-e96c5b",
-    "s-ee5f0f",
-    "s-f14e54"
+    "2c9771bbedcff6dd",
+    "56010225ff0ab920",
+    "5868947a17d96307",
+    "aee15e08901aeb09",
+    "d89c5a90ca3a34c7",
+    "dcb55d74aaa6da0d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5287,11 +5287,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2c53a0": -2,
-       "s-303c45": 2,
-       "s-92a99c": 1,
-       "s-e51036": 2,
-       "s-e96c5b": -3
+       "052fedcc80906af5": 1,
+       "5d04c3bda54b4093": 2,
+       "cc524dcdfdc4922c": 2,
+       "d89c5a90ca3a34c7": -3,
+       "dcb55d74aaa6da0d": -2
       }
      }
     }
@@ -5305,8 +5305,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-c42317",
-    "r-8ccfd3"
+    "5da9f224435a3ce9",
+    "a7d0a878acc2a741"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5334,8 +5334,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-6c5e87": 1,
-       "o-c42317": -1
+       "61f1f753d4258d79": 1,
+       "a7d0a878acc2a741": -1
       }
      }
     }
@@ -5349,7 +5349,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-8222d3"
+    "05c58ed305fdd989"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5377,8 +5377,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3e5388": 1,
-       "s-8222d3": -1
+       "05c58ed305fdd989": -1,
+       "ec07cbd73e0548c9": 1
       }
      }
     }
@@ -5392,8 +5392,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-baaec6",
-    "s-7288b2"
+    "236fd924bbccf909",
+    "2af80f0cd71ffd04"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5421,8 +5421,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-7288b2": -1,
-       "s-a461a2": 1
+       "236fd924bbccf909": -1,
+       "4142ceeed8478058": 1
       }
      }
     }
@@ -5436,7 +5436,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-2b22b7"
+    "db16e395964035dc"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5464,10 +5464,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2b22b7": -3,
-       "s-846292": 1,
-       "s-84701e": 1,
-       "s-ff1be2": 1
+       "6d7d66eccd7e5fb6": 1,
+       "7d5b4c30e50b621b": 1,
+       "db16e395964035dc": -3,
+       "f830038bd235ef94": 1
       }
      }
     }
@@ -5481,10 +5481,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-2e6a07",
-    "r-6a040b",
-    "r-8bbb22",
-    "s-cef9dd"
+    "a438b3fd53af2b41",
+    "b7921afa5053af71",
+    "ccb8559a63c94dc4",
+    "e087252164646a39"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5512,9 +5512,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-584d35": 1,
-       "s-cef9dd": -2,
-       "s-e54430": 1
+       "067988309da80c4a": 1,
+       "4e9d7c1dbe0af14a": 1,
+       "a438b3fd53af2b41": -2
       }
      }
     }
@@ -5528,7 +5528,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-42706d"
+    "35eca46a8612f8f9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5556,14 +5556,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-400d24": 1,
-       "s-42706d": -7,
-       "s-4fcbba": 1,
-       "s-68504d": 1,
-       "s-7af424": 1,
-       "s-d4f689": 1,
-       "s-d6067f": 1,
-       "s-fb6510": 1
+       "25954525672f3ed7": 1,
+       "34126d9f5a0234c3": 1,
+       "35eca46a8612f8f9": -7,
+       "53fccb2279d61c5b": 1,
+       "69091fb111ce38ae": 1,
+       "8daa7895671bb709": 1,
+       "d6b6fbbe79b78071": 1,
+       "ff33adcc0386469e": 1
       }
      }
     }
@@ -5577,8 +5577,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-3d5d2d",
-    "s-b3ca49"
+    "401028f1bf6b9c27",
+    "f211f38da865690c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5606,9 +5606,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3d5d2d": -1,
-       "s-b3ca49": -1,
-       "s-b9f5aa": 2
+       "401028f1bf6b9c27": -1,
+       "a861a8153d81ca8f": 2,
+       "f211f38da865690c": -1
       }
      }
     }
@@ -5622,7 +5622,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-3d99c1"
+    "27d0757f5e5b7a64"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5650,8 +5650,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-26c6e7": 1,
-       "s-3d99c1": -1
+       "27d0757f5e5b7a64": -1,
+       "49a40f1c1dc72d0d": 1
       }
      }
     }
@@ -5665,7 +5665,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-63bd17"
+    "da808090c3b2ba86"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5693,8 +5693,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-63bd17": -1,
-       "s-73fb84": 1
+       "52c9a15e2bc24450": 1,
+       "da808090c3b2ba86": -1
       }
      }
     }
@@ -5708,7 +5708,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-57f696"
+    "ec8c5d3f08f34146"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5736,8 +5736,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-57f696": -1,
-       "o-e73347": 1
+       "8b5d6b93d24ebf26": 1,
+       "ec8c5d3f08f34146": -1
       }
      }
     }
@@ -5751,7 +5751,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-13aaa8"
+    "78cb009ab9ba1b34"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5779,10 +5779,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-13aaa8": -3,
-       "s-6dff4c": 1,
-       "s-a58c2f": 1,
-       "s-b1cbbb": 1
+       "66e4b2e90f42ca92": 1,
+       "78cb009ab9ba1b34": -3,
+       "b1ae42436ffc1275": 1,
+       "ee9402b89d5ebfb3": 1
       }
      }
     }
@@ -5796,7 +5796,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-dcb735"
+    "386a1aa71e64e857"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5824,8 +5824,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-b525b6": 1,
-       "s-dcb735": -1
+       "386a1aa71e64e857": -1,
+       "ad51e450c74a5869": 1
       }
      }
     }
@@ -5839,7 +5839,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "u-bea2fe"
+    "7ad19fa41c401147"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5867,9 +5867,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-bea2fe": -2,
-       "u-c47fcc": 1,
-       "u-ebe03b": 1
+       "670cb155560549d9": 1,
+       "7ad19fa41c401147": -2,
+       "88fcc69bbb88f3b7": 1
       }
      }
     }
@@ -5883,7 +5883,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-13aaa8"
+    "78cb009ab9ba1b34"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5911,10 +5911,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-13aaa8": -3,
-       "s-6dff4c": 1,
-       "s-a58c2f": 1,
-       "s-b1cbbb": 1
+       "66e4b2e90f42ca92": 1,
+       "78cb009ab9ba1b34": -3,
+       "b1ae42436ffc1275": 1,
+       "ee9402b89d5ebfb3": 1
       }
      }
     }
@@ -5928,7 +5928,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-13aaa8"
+    "78cb009ab9ba1b34"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -5956,10 +5956,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-13aaa8": -3,
-       "s-6dff4c": 1,
-       "s-a58c2f": 1,
-       "s-b1cbbb": 1
+       "66e4b2e90f42ca92": 1,
+       "78cb009ab9ba1b34": -3,
+       "b1ae42436ffc1275": 1,
+       "ee9402b89d5ebfb3": 1
       }
      }
     }
@@ -5973,7 +5973,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-0f06e5"
+    "3b0eb7630befb407"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6001,8 +6001,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0f06e5": -1,
-       "o-e098a9": 1
+       "3b0eb7630befb407": -1,
+       "8f192a113e2dc85c": 1
       }
      }
     }
@@ -6016,7 +6016,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-0f06e5"
+    "3b0eb7630befb407"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6044,8 +6044,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0f06e5": -1,
-       "o-e098a9": 1
+       "3b0eb7630befb407": -1,
+       "8f192a113e2dc85c": 1
       }
      }
     }
@@ -6059,7 +6059,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-f3571d"
+    "29bec5175c3bdb1d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6087,10 +6087,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6a60db": 1,
-       "s-8d1d1a": 1,
-       "s-d1deec": 1,
-       "s-f3571d": -3
+       "29bec5175c3bdb1d": -3,
+       "5e83417248245dec": 1,
+       "d951ac30ce638383": 1,
+       "dc61a4fb2ccaf6f9": 1
       }
      }
     }
@@ -6104,7 +6104,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-f09533"
+    "a61b05c456b11340"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6132,9 +6132,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0c1815": 1,
-       "s-46ef78": 1,
-       "s-f09533": -2
+       "51a876af19ff335b": 1,
+       "944020b93c2fe9c6": 1,
+       "a61b05c456b11340": -2
       }
      }
     }
@@ -6148,7 +6148,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-7523ef"
+    "67582bd322c132e3"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6176,9 +6176,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0341cc": 1,
-       "s-7523ef": -2,
-       "s-ab72d3": 1
+       "17d630f5ff6ab8d9": 1,
+       "67582bd322c132e3": -2,
+       "969ce183174a1197": 1
       }
      }
     }
@@ -6192,7 +6192,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-8e3a6c0e74df"
+    "2fb07191f4298060"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6226,11 +6226,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2c2200e04628": 1,
-       "o-837632290379": 1,
-       "o-8e3a6c0e74df": -4,
-       "o-beb29261b342": 1,
-       "o-f71a52246f2e": 1
+       "228b90247f7820f3": 1,
+       "2fb07191f4298060": -4,
+       "bd910064d55b52f7": 1,
+       "cba8ee8c08a5e189": 1,
+       "d45671b52525b12b": 1
       }
      }
     }
@@ -6244,10 +6244,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-3253a18a2154",
-    "r-aec21dbf131c",
-    "s-32dd7b72385e",
-    "s-bf358665add2"
+    "505c6fcb01a77b88",
+    "5f37319ce7db8212",
+    "71ef62581c020e22",
+    "eaecb6fb26904fa2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6272,12 +6272,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-8dbedbaaca57",
-       "s-b234b013d733"
+       "3207bf68c3843ea1",
+       "bad07e70e341cd98"
       ],
       "only_ungated": [
-       "s-32dd7b72385e",
-       "s-bf358665add2"
+       "505c6fcb01a77b88",
+       "eaecb6fb26904fa2"
       ]
      },
      "rank_diff": {
@@ -6285,15 +6285,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-32dd7b72385e": -7,
-       "s-352a468d0fa1": 2,
-       "s-54eacaeab14f": 1,
-       "s-5af25ca91a9b": 2,
-       "s-635a8a71a8e6": 1,
-       "s-76371b591f6e": 2,
-       "s-8dbedbaaca57": 2,
-       "s-b234b013d733": 2,
-       "s-bf358665add2": -5
+       "140c05a55941638a": 2,
+       "3207bf68c3843ea1": 2,
+       "505c6fcb01a77b88": -5,
+       "97d77f53854fe58e": 1,
+       "9976f0fa9ee3fd28": 1,
+       "b523cd28bb94e972": 2,
+       "bad07e70e341cd98": 2,
+       "c21fd09202b93380": 2,
+       "eaecb6fb26904fa2": -7
       }
      }
     }
@@ -6307,7 +6307,7 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-d0246fc247f9"
+    "6a38700504f5047a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6341,9 +6341,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-d0246fc247f9": -2,
-       "s-d98d6f640ded": 1,
-       "s-f86a74f5f1b3": 1
+       "6a38700504f5047a": -2,
+       "84435ccad7dab4e6": 1,
+       "f8b39e3c9e9120bb": 1
       }
      }
     }
@@ -6357,8 +6357,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-04fe20442c70",
-    "s-ae0ba2390fc8"
+    "5b74ac18311429b6",
+    "e84ce204554be642"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6390,8 +6390,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-04fe20442c70": -1,
-       "s-787916be872e": 1
+       "00e7c0d3bba6f026": 1,
+       "e84ce204554be642": -1
       }
      }
     }
@@ -6405,16 +6405,16 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "o-a25007f4c6e3",
-    "r-304a4ed4f0d4",
-    "r-3b021e7ba8c5",
-    "r-4f62fd1dff95",
-    "r-bf4ee92d41bb",
-    "s-15609a6f3c71",
-    "s-4db06d37106e",
-    "s-615b988a4f25",
-    "s-7ac48c95c8b3",
-    "s-a4b2a6e5733c"
+    "089edb92b90c85c1",
+    "356bf23b3ee38af9",
+    "4f6742ed7538a441",
+    "5eac7e58ca460a3a",
+    "66c223ca93a4d551",
+    "6ff087e9b56c2057",
+    "7f5e8cf223609cab",
+    "9850b76e1404be87",
+    "a7f203f4334cf227",
+    "d0080726a7e4e9d9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6439,10 +6439,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-936972dfead1"
+       "a5ad6282af1c8e46"
       ],
       "only_ungated": [
-       "s-a4b2a6e5733c"
+       "089edb92b90c85c1"
       ]
      },
      "rank_diff": {
@@ -6450,18 +6450,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-06961db383db": 5,
-       "s-15609a6f3c71": -2,
-       "s-4db06d37106e": -4,
-       "s-615b988a4f25": -3,
-       "s-6a6982330cce": 4,
-       "s-7ac48c95c8b3": -4,
-       "s-936972dfead1": 1,
-       "s-9c6e42d76a4a": 5,
-       "s-a4b2a6e5733c": -7,
-       "s-b605da8fdabe": 1,
-       "s-ba9ee60f1393": 1,
-       "s-cbd74b84ec45": 3
+       "089edb92b90c85c1": -7,
+       "08ad8796fdfb1561": 4,
+       "1156c13596559a74": 3,
+       "24356bdea8003818": 1,
+       "28b1d071c5742e74": 1,
+       "4f6742ed7538a441": -3,
+       "5eac7e58ca460a3a": -4,
+       "7ec0b8f5385c5e6c": 5,
+       "7f5e8cf223609cab": -4,
+       "a5ad6282af1c8e46": 1,
+       "bfe8d94193e0c097": 5,
+       "d0080726a7e4e9d9": -2
       }
      }
     }
@@ -6475,23 +6475,23 @@
    "n_flipped_items": 19,
    "n_lid_biting_flips": 17,
    "lid_biting_items": [
-    "h:99e42dfe2938",
-    "r-0f1d56e656b7",
-    "r-2009748f4cdb",
-    "r-6ad17412b0be",
-    "r-9731ddc4f174",
-    "r-9867c097bf4d",
-    "r-a3eaa03cf828",
-    "r-c044d7edb5f0",
-    "r-e69bc19bd0e6",
-    "s-04dece143d52",
-    "s-28643d000f9a",
-    "s-35697cf0a7b2",
-    "s-55cedf866b6f",
-    "s-730748221d37",
-    "s-8819f107781a",
-    "s-b6c81807b5e7",
-    "s-bafaa6b06351"
+    "0ba483b9f2bef654",
+    "106483b9bbab5f52",
+    "27b582d792e30b3c",
+    "3ccbc75a3a13a7b9",
+    "452efa74a232ac7b",
+    "499601545b6f9800",
+    "7638e5cbbf30b49a",
+    "7cccfc984bee80a0",
+    "8c29714a744cdc28",
+    "95a6caf4d193ef6d",
+    "b68850760f8ebf05",
+    "b8f4ff2a60a17fec",
+    "c4b262330d9d1c52",
+    "ca3ab71d3c3e95e5",
+    "dd36e028404adce1",
+    "eff6a936f00fba64",
+    "f92428e917a274db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6527,26 +6527,26 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-020468f1dfeb": 7,
-       "s-0225b0e6e55b": 4,
-       "s-04dece143d52": -5,
-       "s-216e1695c671": 5,
-       "s-28643d000f9a": -8,
-       "s-335347ed6e2b": 1,
-       "s-35697cf0a7b2": -3,
-       "s-375fc7c30a01": 3,
-       "s-55cedf866b6f": -5,
-       "s-652ea2ccda71": 4,
-       "s-730748221d37": -9,
-       "s-7969f3ade184": 3,
-       "s-861bb07a6014": 4,
-       "s-8819f107781a": -9,
-       "s-ad36fc031bb5": 7,
-       "s-b6c81807b5e7": -5,
-       "s-bac5f45c7579": 7,
-       "s-bafaa6b06351": -9,
-       "s-d4c29ad5eea3": 4,
-       "s-eda44702896b": 4
+       "035a58eb8d6750be": 4,
+       "106483b9bbab5f52": -8,
+       "27b582d792e30b3c": -5,
+       "2a0b8bc85ec92a4d": 4,
+       "39466bee7d61f9de": 1,
+       "396df1d9b152dee0": 3,
+       "39708e1aacdcf968": 4,
+       "452efa74a232ac7b": -3,
+       "7b2ba2134e97e665": 7,
+       "7b3fb8be79306dad": 7,
+       "7cccfc984bee80a0": -5,
+       "8c29714a744cdc28": -9,
+       "992e040b9e99dda3": 3,
+       "aeece569386179d2": 5,
+       "b2c472bc75dd8185": 7,
+       "b8f4ff2a60a17fec": -5,
+       "dd36e028404adce1": -9,
+       "f92428e917a274db": -9,
+       "fc7d4ab7f2a16d4a": 4,
+       "fe3408a427b71ab5": 4
       }
      }
     }
@@ -6560,19 +6560,19 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 13,
    "lid_biting_items": [
-    "h:4cbf0acbdd73",
-    "o-5b8df357c64d",
-    "r-01e87a33ad7a",
-    "r-05d4d3cb90ce",
-    "r-498681ab50a8",
-    "r-622ee6d6c2ed",
-    "r-782c8a1e7971",
-    "r-78726d23d29e",
-    "r-98f6a04559e7",
-    "r-c68c7be529ff",
-    "r-cfa70b9c6559",
-    "s-3662aca3c5e6",
-    "s-f1d0e84ff346"
+    "0c8efd2fa37df24e",
+    "3de5c6898d307441",
+    "5508637f7c79ffca",
+    "590188768634d4a7",
+    "a6cc10956e30bed2",
+    "aaa999a8c820216a",
+    "aff3c5e6b7e984d6",
+    "b1392ae95561c562",
+    "b897ab877b60b76e",
+    "c3844f4df56cfab8",
+    "e5599b7f20376bfe",
+    "ebeb979a52b27a0b",
+    "efe815aae3282264"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6604,9 +6604,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-46389c74b8fe": 1,
-       "o-5b8df357c64d": -2,
-       "o-9ac19e49ba62": 1
+       "a37877a42a85a1d7": 1,
+       "a6cc10956e30bed2": -2,
+       "f519f30a971a3c8f": 1
       }
      }
     },
@@ -6622,10 +6622,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6427f5243dfa": 1,
-       "s-7233d967d13e": 1,
-       "s-a2250fe46105": 1,
-       "s-f1d0e84ff346": -3
+       "007204cf9a7c3e81": 1,
+       "8d417fdf1afd7481": 1,
+       "c3844f4df56cfab8": -3,
+       "c7d9a1e6dc951908": 1
       }
      }
     }
@@ -6639,8 +6639,8 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-cd0c8950dc84",
-    "s-ed1cc815927c"
+    "09086e2b06b980b9",
+    "565b7a81d2401246"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6668,8 +6668,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-4e26d42f9eb7": 1,
-       "s-ed1cc815927c": -1
+       "565b7a81d2401246": -1,
+       "c443376de39cf7cd": 1
       }
      }
     }
@@ -6683,9 +6683,9 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-cd0c8950dc84",
-    "s-7386c2726710",
-    "s-965ced9f8e9d"
+    "09086e2b06b980b9",
+    "1c7c7597907562c5",
+    "641beeafa5120aa6"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6713,12 +6713,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0da92b5b1402": 2,
-       "s-7386c2726710": -3,
-       "s-965ced9f8e9d": -4,
-       "s-982db6a12498": 1,
-       "s-aa347f598139": 2,
-       "s-e260ed2a610a": 2
+       "1c7c7597907562c5": -4,
+       "5f32f49e0c04e5af": 2,
+       "641beeafa5120aa6": -3,
+       "9c3f90bfb634a596": 1,
+       "c45d4860bb100fd2": 2,
+       "c930994c30f76c34": 2
       }
      }
     }
@@ -6732,11 +6732,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-47cbbb4fb209",
-    "s-27ac16e736ed",
-    "s-8188c7a828c4",
-    "s-9d94ac26b546",
-    "u-c6131e775fe4"
+    "0a5d22f99c0df623",
+    "4b064e58e7229998",
+    "895e2cd0edbcfb1f",
+    "8e29f196973654b3",
+    "9ea4d263f0135f6b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6768,13 +6768,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0e9ba98943ff": 2,
-       "s-1a5f8c6eee8b": 3,
-       "s-27ac16e736ed": -1,
-       "s-3653d2277143": 2,
-       "s-8188c7a828c4": -4,
-       "s-9d94ac26b546": -4,
-       "s-ad6cdb000f74": 2
+       "0a5d22f99c0df623": -4,
+       "4b064e58e7229998": -4,
+       "7a5d13f4a48a3162": 2,
+       "8d0b713fe9331c59": 2,
+       "9825c4278ea3045c": 3,
+       "9ea4d263f0135f6b": -1,
+       "e57cd71db82c8d6d": 2
       }
      }
     }
@@ -6788,9 +6788,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "h:71680316bdb6",
-    "r-b474e2151408",
-    "s-3a94c506987c"
+    "4f0990c9d9774ea6",
+    "81269ace5fb10ef8",
+    "c448f61190a5e85d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6818,8 +6818,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3a94c506987c": -1,
-       "s-a91c3b98c508": 1
+       "81269ace5fb10ef8": -1,
+       "9f6d9827045e52ac": 1
       }
      }
     }
@@ -6833,12 +6833,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-1fd8f63ffc9a",
-    "r-50d6258c2050",
-    "r-64cc8d3673e9",
-    "s-5b8463ca4c3b",
-    "s-612b1eecc162",
-    "s-e2fded700c7a"
+    "2f8e0d5f6f14a8e5",
+    "6ca9748e13ea246e",
+    "79c3e7de5c82b64f",
+    "8d289ec47bf916f0",
+    "d8b0ed5319deb13e",
+    "e4f99c1569f4bc17"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6870,12 +6870,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2dc093e62750": 3,
-       "s-4eff64efc019": 2,
-       "s-5b8463ca4c3b": -2,
-       "s-612b1eecc162": -3,
-       "s-8140031f08ec": 3,
-       "s-e2fded700c7a": -3
+       "09ba55ff91c79caf": 3,
+       "67316c64e4a8ffdd": 2,
+       "6ca9748e13ea246e": -3,
+       "b6fdb569096088bc": 3,
+       "d8b0ed5319deb13e": -2,
+       "e4f99c1569f4bc17": -3
       }
      }
     }
@@ -6889,12 +6889,12 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-2c6bfd640474",
-    "r-2cfd99886915",
-    "r-cbb8e6798a8f",
-    "r-dda72a321849",
-    "r-fdaa730b26e3",
-    "s-95a34473f0db"
+    "3a170d4872eabec5",
+    "9b5c1586dd5c6159",
+    "ab4df7e68405bd81",
+    "ad6aafa795dd611c",
+    "e4fa8614d94325d9",
+    "e71103997040055c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6919,10 +6919,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-9e25870ae5a7"
+       "6cb1402e5a48c06d"
       ],
       "only_ungated": [
-       "s-95a34473f0db"
+       "ad6aafa795dd611c"
       ]
      },
      "rank_diff": {
@@ -6930,16 +6930,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0a0b9409d089": 1,
-       "s-1d844919adbe": 1,
-       "s-30dbf21dc389": 1,
-       "s-3afe38c7b37b": 1,
-       "s-4cc18a4f504b": 1,
-       "s-8c79a4474cb7": 1,
-       "s-95a34473f0db": -9,
-       "s-9e25870ae5a7": 1,
-       "s-a2daf26de8e8": 1,
-       "s-c9709620a88b": 1
+       "015d6de362f5f4a6": 1,
+       "1a653ed5d899c6fd": 1,
+       "3959d27f250dbc91": 1,
+       "617ff8f5a5bc9e67": 1,
+       "691652c0e1632278": 1,
+       "6cb1402e5a48c06d": 1,
+       "905578a23cd164eb": 1,
+       "9509ad440f4ca388": 1,
+       "ad6aafa795dd611c": -9,
+       "b3bce227f645d6a3": 1
       }
      }
     }
@@ -6953,7 +6953,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-92e8533d3b1b"
+    "a32e49ffa87048c0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -6985,11 +6985,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-165a15625ee4": 1,
-       "s-58c775a74778": 1,
-       "s-617413be7236": 1,
-       "s-92e8533d3b1b": -4,
-       "s-df007c78e928": 1
+       "66139f9b218a88f3": 1,
+       "6e7fc5bb1bbe3deb": 1,
+       "704d35a36a507fc0": 1,
+       "a32e49ffa87048c0": -4,
+       "e8251106923790b5": 1
       }
      }
     }
@@ -7003,8 +7003,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-165cc577e14e",
-    "s-c72f6bb3e55d"
+    "182aa566b7404ecc",
+    "b14513f80595036d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7038,8 +7038,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-c72f6bb3e55d": -1,
-       "s-d0df47761f6c": 1
+       "6488f8d3b152541d": 1,
+       "b14513f80595036d": -1
       }
      }
     }
@@ -7053,11 +7053,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-05d5cc118883",
-    "r-80b226337f04",
-    "s-3ad2e68c81e0",
-    "s-4fb7063ee795",
-    "s-85ad2f367e5b"
+    "3397618326dcb8af",
+    "3421dcf2721cfa32",
+    "457413edf73c971d",
+    "8d5ecf8c083bb864",
+    "e5bafed9f0c72347"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7089,12 +7089,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3ad2e68c81e0": -1,
-       "s-3ee6cbe0cf39": 1,
-       "s-4fb7063ee795": -3,
-       "s-85ad2f367e5b": -1,
-       "s-8967aa99c960": 3,
-       "s-c990525d81c4": 1
+       "06629b06c4d6262c": 1,
+       "3397618326dcb8af": -3,
+       "3421dcf2721cfa32": -1,
+       "457413edf73c971d": -1,
+       "70565553c3bc1009": 1,
+       "f4209f973a7c9db4": 3
       }
      }
     }
@@ -7108,8 +7108,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-ad5991c7c565",
-    "s-1794685f8714"
+    "059827629653b504",
+    "ca5dcc4a15db8b82"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7143,12 +7143,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1794685f8714": -5,
-       "s-85af95d36859": 1,
-       "s-861952d98dd3": 1,
-       "s-8d955adb3f80": 1,
-       "s-aed8a2b77fa7": 1,
-       "s-c9622f7b9bef": 1
+       "32b9ef2c04904d18": 1,
+       "552bfe191a000c34": 1,
+       "b18fef0cb659ed41": 1,
+       "ca5dcc4a15db8b82": -5,
+       "e1dffd4a27fa9166": 1,
+       "fa506d0caa959ae0": 1
       }
      }
     }
@@ -7162,14 +7162,14 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "o-138d96",
-    "s-24d88de82f58",
-    "s-4bd044ed8544",
-    "s-526cc12d9141",
-    "s-571e15bc61c3",
-    "s-6ac375c86e3b",
-    "s-7f47d142adcc",
-    "s-da3d1825074d"
+    "0c5ae26cc5bde0e2",
+    "1f79476933ac1794",
+    "40630c107542017d",
+    "af77157ffb2dc8e2",
+    "b4ce9aed7806ebc5",
+    "d709706c03e5abc9",
+    "e9365d10fd808b3d",
+    "f4064aaebb1ee1f9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7194,15 +7194,15 @@
      "cap_crossings": {
       "count": 7,
       "only_gated": [
-       "s-001cdb652452",
-       "s-272ade03e625",
-       "s-47bb42e5b221",
-       "s-4ca6bae2daa8"
+       "3f17cbdcfd8b2ffb",
+       "69af2ac798d6787a",
+       "707ae32d992a09c0",
+       "d8fb9d8c0c7ec677"
       ],
       "only_ungated": [
-       "s-526cc12d9141",
-       "s-6ac375c86e3b",
-       "s-da3d1825074d"
+       "af77157ffb2dc8e2",
+       "e9365d10fd808b3d",
+       "f4064aaebb1ee1f9"
       ]
      },
      "rank_diff": {
@@ -7210,24 +7210,24 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-001cdb652452": 5,
-       "s-10325891c711": 7,
-       "s-1126a7afe8ac": 1,
-       "s-24d88de82f58": -3,
-       "s-272ade03e625": 5,
-       "s-47bb42e5b221": 4,
-       "s-4bd044ed8544": -5,
-       "s-4ca6bae2daa8": 3,
-       "s-526cc12d9141": -9,
-       "s-54788c3c1f0a": 6,
-       "s-571e15bc61c3": -2,
-       "s-578aaf1eac04": 5,
-       "s-6792676f8e89": 3,
-       "s-6ac375c86e3b": -9,
-       "s-74ac2f372644": 1,
-       "s-7f47d142adcc": -6,
-       "s-a1fcd3f977d1": 3,
-       "s-da3d1825074d": -9
+       "0c5ae26cc5bde0e2": -6,
+       "1f79476933ac1794": -2,
+       "27ba19bc45eccc25": 1,
+       "3396bd9c96771fe1": 1,
+       "3f17cbdcfd8b2ffb": 3,
+       "40630c107542017d": -3,
+       "65bdb5f4b4a015f2": 6,
+       "69af2ac798d6787a": 5,
+       "69ee7cda6a363aa2": 7,
+       "707ae32d992a09c0": 5,
+       "8c8fc5934b85d79f": 3,
+       "8f9514686e53cd9c": 5,
+       "af77157ffb2dc8e2": -9,
+       "b4ce9aed7806ebc5": -5,
+       "d8fb9d8c0c7ec677": 4,
+       "e9365d10fd808b3d": -9,
+       "f3ddac3b2b302c7d": 3,
+       "f4064aaebb1ee1f9": -9
       }
      }
     }
@@ -7241,29 +7241,29 @@
    "n_flipped_items": 24,
    "n_lid_biting_flips": 23,
    "lid_biting_items": [
-    "h:e348bd14a6a0",
-    "o-138d96",
-    "o-e3d6ed",
-    "r-0d9556",
-    "r-0ff515",
-    "r-268ef8",
-    "r-3935fc",
-    "r-4f86df",
-    "r-7008c5",
-    "r-92ccc5",
-    "r-9f3f62",
-    "r-a49e53",
-    "r-a525fd",
-    "r-c23d8c",
-    "r-c8487e",
-    "r-e73773",
-    "r-f8fa74",
-    "s-5aaeac",
-    "s-5bd7b8",
-    "s-612a68",
-    "s-8efa49",
-    "s-93d5a8",
-    "u-b1055f"
+    "01ac67902bc157d3",
+    "13f9393a98894f3f",
+    "2d2d855fbff4e731",
+    "30eaf1e623d95bf0",
+    "32060e3cdede0f40",
+    "374761b412b48760",
+    "3ab5e62eb51ad923",
+    "45a7592145215d6f",
+    "53330d9a6cfdcf58",
+    "585b3589f6a7c5da",
+    "8478acc71b4c6bdf",
+    "8539bb3b9a2b2ed4",
+    "9ba393abe7fac688",
+    "9e7fec30b1c03d25",
+    "a0149f3001b72fab",
+    "a13303d67cc41061",
+    "a8c33b9163a4799f",
+    "c0f1ab7eb266e2bc",
+    "c74bb21cb5fce829",
+    "ce91123ce15b0d15",
+    "d709706c03e5abc9",
+    "e98b1290b8fcec17",
+    "ecebcfe22a96fa4b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7295,15 +7295,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-138d96": -7,
-       "o-4c5297": 1,
-       "o-569baf": 2,
-       "o-6774b0": 1,
-       "o-7dd51a": 1,
-       "o-9f9e46": 2,
-       "o-b4c702": 1,
-       "o-e3d6ed": -2,
-       "o-e989bf": 1
+       "1630e01b32b81b2c": 2,
+       "1876da6160b4bb91": 2,
+       "1a0a7e21e21ab2be": 1,
+       "21a4cd8a5fc5f8b2": 1,
+       "422e97bd02d8d6b2": 1,
+       "50a383740460cd4d": 1,
+       "585b3589f6a7c5da": -2,
+       "c3800b8dde53857d": 1,
+       "d709706c03e5abc9": -7
       }
      }
     },
@@ -7319,19 +7319,19 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-140db4": 5,
-       "s-5aaeac": -6,
-       "s-5bd7b8": -8,
-       "s-6071cd": 5,
-       "s-612a68": -4,
-       "s-7fcf87": 2,
-       "s-83a8a4": 1,
-       "s-882206": 5,
-       "s-8efa49": -4,
-       "s-93d5a8": -4,
-       "s-a44b12": 2,
-       "s-a66475": 1,
-       "s-b99a2b": 5
+       "0df7540daa77b1a8": 5,
+       "2d2d855fbff4e731": -4,
+       "3114ab205458a3ab": 5,
+       "374761b412b48760": -6,
+       "3ab5e62eb51ad923": -8,
+       "73fd2dc153a62575": 1,
+       "9ba393abe7fac688": -4,
+       "9c3b36f7cd270b10": 5,
+       "a8c33b9163a4799f": -4,
+       "b102d490caca0480": 2,
+       "b571db0116743a78": 5,
+       "f616fb23f246ab7e": 2,
+       "f6a280b006e7a3f4": 1
       }
      }
     }
@@ -7345,8 +7345,8 @@
    "n_flipped_items": 24,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-138d96",
-    "o-e3d6ed"
+    "585b3589f6a7c5da",
+    "d709706c03e5abc9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7378,15 +7378,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-138d96": -6,
-       "o-4c5297": 1,
-       "o-569baf": 1,
-       "o-6774b0": 1,
-       "o-7dd51a": 1,
-       "o-9f9e46": 1,
-       "o-b4c702": 1,
-       "o-e3d6ed": -1,
-       "o-e989bf": 1
+       "1630e01b32b81b2c": 1,
+       "1876da6160b4bb91": 1,
+       "1a0a7e21e21ab2be": 1,
+       "21a4cd8a5fc5f8b2": 1,
+       "422e97bd02d8d6b2": 1,
+       "50a383740460cd4d": 1,
+       "585b3589f6a7c5da": -1,
+       "c3800b8dde53857d": 1,
+       "d709706c03e5abc9": -6
       }
      }
     }
@@ -7400,8 +7400,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-691764ddd72c",
-    "s-f52419c599b1"
+    "1f423e4a27fb71bf",
+    "cb10a2a1bc102915"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7433,11 +7433,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0fa50a112a7c": 1,
-       "s-628d1089a75a": 1,
-       "s-76e79f34ce14": 1,
-       "s-9ed3d693c69e": 1,
-       "s-f52419c599b1": -4
+       "73c3caa287d02b49": 1,
+       "7bca8c25d0c7a34e": 1,
+       "a62dc11cf80628c9": 1,
+       "c6f37fbbc6b9407e": 1,
+       "cb10a2a1bc102915": -4
       }
      }
     }
@@ -7451,9 +7451,9 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-584f87a6e6ff",
-    "r-76437c462918",
-    "s-83e89144cb27"
+    "1c6d2bf7ecc53ae3",
+    "4d162194f9faacb7",
+    "79f3f1385a3ad475"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7487,11 +7487,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-535c522dd09b": 1,
-       "s-699ae47ec3ee": 1,
-       "s-83e89144cb27": -4,
-       "s-f35978b781b0": 1,
-       "s-f6de5ed82b34": 1
+       "1c6d2bf7ecc53ae3": -4,
+       "51d91a8ea9f3fa85": 1,
+       "64f61e92d0fbaf54": 1,
+       "7130f5eec4a9b1ed": 1,
+       "9072ecc95365671e": 1
       }
      }
     }
@@ -7505,11 +7505,11 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-38a0bb3be0f1",
-    "r-9a7d98cae503",
-    "s-092216a692db",
-    "s-4630b8adac76",
-    "s-79b0a318fd82"
+    "1fe489dc68e56070",
+    "7b1be34876862205",
+    "9719f6d091d8938e",
+    "9fba86b13abdbff7",
+    "f0176004367b80a7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7541,14 +7541,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-092216a692db": -3,
-       "s-1709fc2250c8": 1,
-       "s-4630b8adac76": -2,
-       "s-56fee8dcaf96": 3,
-       "s-79b0a318fd82": -4,
-       "s-c40daa50e69c": 3,
-       "s-cbfd41611a09": 1,
-       "s-f35978b781b0": 1
+       "25ac751413f289bc": 1,
+       "456d8a89e00f7aa9": 3,
+       "51d91a8ea9f3fa85": 1,
+       "7b1be34876862205": -3,
+       "7b2719754e5cc740": 1,
+       "9719f6d091d8938e": -2,
+       "9fba86b13abdbff7": -4,
+       "e511035d0b333b33": 3
       }
      }
     }
@@ -7562,11 +7562,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "o-0c534ec233e5",
-    "s-2cc172cfb276",
-    "s-43dba42d9c9b",
-    "s-a58bb909c4eb",
-    "s-f8968b74104d"
+    "3c399ddb608cf8a6",
+    "5a1889e221e2fe32",
+    "60398463bc156137",
+    "887ae7d474c19c1f",
+    "f4c30fd95588b74b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7600,8 +7600,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0c534ec233e5": -1,
-       "o-ab45356f01bb": 1
+       "5a1889e221e2fe32": -1,
+       "e36ac2e638ef7c73": 1
       }
      }
     },
@@ -7617,15 +7617,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-09d5ee757f1f": 3,
-       "s-2cc172cfb276": -1,
-       "s-3a111d158a31": 1,
-       "s-3bc4dcee0111": 1,
-       "s-3d1f5132ef42": 4,
-       "s-43dba42d9c9b": -5,
-       "s-a58bb909c4eb": -2,
-       "s-bdef55880e16": 1,
-       "s-f8968b74104d": -2
+       "227303076c2854b4": 3,
+       "3c399ddb608cf8a6": -5,
+       "49cb70a429ba880f": 1,
+       "60398463bc156137": -2,
+       "887ae7d474c19c1f": -2,
+       "c4b48b8572d20c46": 1,
+       "e2e35f76f92ad28e": 4,
+       "e3ca72785e8db5bd": 1,
+       "f4c30fd95588b74b": -1
       }
      }
     }
@@ -7639,11 +7639,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "h:27736e92e6e1",
-    "o-8d8ae223d83e",
-    "r-41c555a1df1e",
-    "s-ce89d202fa83",
-    "s-d9af82ba3853"
+    "2a5d68b8bda1f3cc",
+    "990c064af022e30d",
+    "b1590ae2dab491a7",
+    "d1d366dd04e1f781",
+    "ff3013b189ecaed3"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7675,8 +7675,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2c3bf6e39430": 1,
-       "o-8d8ae223d83e": -1
+       "074d50098689ee85": 1,
+       "990c064af022e30d": -1
       }
      }
     },
@@ -7692,10 +7692,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-201e63869049": 2,
-       "s-afa963ca3cc0": 2,
-       "s-ce89d202fa83": -2,
-       "s-d9af82ba3853": -2
+       "40bebedc6d23bac7": 2,
+       "d1d366dd04e1f781": -2,
+       "e1cb4a29e6a57257": 2,
+       "ff3013b189ecaed3": -2
       }
      }
     }
@@ -7709,7 +7709,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-4f8ec49e308e"
+    "cca617c0dffdad35"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7737,8 +7737,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1d84784f5ca3": 1,
-       "s-4f8ec49e308e": -1
+       "8838c98114ebe3b1": 1,
+       "cca617c0dffdad35": -1
       }
      }
     }
@@ -7752,31 +7752,31 @@
    "n_flipped_items": 25,
    "n_lid_biting_flips": 25,
    "lid_biting_items": [
-    "o-4d24b4",
-    "o-768300",
-    "r-17e845",
-    "r-271a32",
-    "r-2cf3c8",
-    "r-376a82",
-    "r-582a3f",
-    "r-63650f",
-    "r-694c83",
-    "r-6efedb",
-    "r-822dcd",
-    "r-9363f6",
-    "r-afff29",
-    "r-ce2752",
-    "r-d4c3d5",
-    "r-d7dbf0",
-    "s-3c3b98",
-    "s-3dc743",
-    "s-50b400",
-    "s-92a6b4",
-    "s-ae9b47",
-    "s-bca5b2",
-    "s-c76fc7",
-    "u-22e44e",
-    "u-7301f8"
+    "0101538798869b75",
+    "039dedb9a64a80b0",
+    "05f05979585b66ed",
+    "06d62c00a607b83c",
+    "0cb066e1930d6c37",
+    "39049654ab1fefeb",
+    "70edb51ac0944c32",
+    "7581b4d8947de730",
+    "768f2632f2fb8d49",
+    "7ab4f7e16d886600",
+    "810acd8b3398b7eb",
+    "884cc67238a9c978",
+    "974f9bce1d905ecb",
+    "975bf3da14f9d75a",
+    "9b98d077592c9689",
+    "ab8639ff17ec6865",
+    "c2eba35320491d39",
+    "cba4e245734db5c8",
+    "e2fca4a5b06ccfbb",
+    "e6b750a7e85bb570",
+    "e6ee7b09a51d6055",
+    "e73963887564631b",
+    "e8758477ade3c261",
+    "f1616cfbade412fe",
+    "f36b12a093c9a801"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7810,17 +7810,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-1a8dba": 1,
-       "o-326f43": 2,
-       "o-46560b": 1,
-       "o-4d24b4": -6,
-       "o-768300": -7,
-       "o-7a5dad": 2,
-       "o-80e544": 1,
-       "o-ce0b06": 1,
-       "o-dfd23e": 1,
-       "o-eff95f": 2,
-       "o-f0f244": 2
+       "06d62c00a607b83c": -7,
+       "196419a716d0fa92": 2,
+       "472d1e7889934f9f": 2,
+       "56f1b9881437945e": 2,
+       "61af6215f6091076": 2,
+       "72a8074535d36672": 1,
+       "7581b4d8947de730": -6,
+       "75e76b6ea7023c4a": 1,
+       "82d4589eab5043cb": 1,
+       "aa979f9a1412318e": 1,
+       "f6f9581a7e4ac64a": 1
       }
      }
     },
@@ -7836,22 +7836,22 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-17741d": 2,
-       "s-3c3b98": -3,
-       "s-3dc743": -9,
-       "s-50b400": -4,
-       "s-6ebaa7": 4,
-       "s-84ba0b": 5,
-       "s-8620dc": 1,
-       "s-922595": 2,
-       "s-9a78b2": 2,
-       "s-a5c49a": 5,
-       "s-ab38bb": 6,
-       "s-ae9b47": -10,
-       "s-bca5b2": -4,
-       "s-c42c6c": 2,
-       "s-c76fc7": -1,
-       "s-d29e01": 2
+       "169fef0b55e68274": 1,
+       "3828c42523135adb": 2,
+       "768f2632f2fb8d49": -3,
+       "810acd8b3398b7eb": -10,
+       "a0388eece3cf811b": 2,
+       "c2eba35320491d39": -9,
+       "c4ceeea38bb0ddd9": 4,
+       "cba4e245734db5c8": -1,
+       "cddac8bbbb6c717f": 2,
+       "d32d9887f3aed67d": 5,
+       "dc5becffda7bb3b0": 2,
+       "e1f05b0b67123e88": 5,
+       "e2fca4a5b06ccfbb": -4,
+       "e73963887564631b": -4,
+       "f816ebed63681330": 6,
+       "f9265a695e67b7c8": 2
       }
      }
     },
@@ -7867,11 +7867,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-22e44e": -1,
-       "u-24047d": 1,
-       "u-558f3a": 2,
-       "u-7301f8": -3,
-       "u-f66894": 1
+       "3b3181437d93fa3d": 1,
+       "4ca5df3d18c03701": 2,
+       "6eef689cf878ed32": 1,
+       "884cc67238a9c978": -1,
+       "e6b750a7e85bb570": -3
       }
      }
     }
@@ -7885,8 +7885,8 @@
    "n_flipped_items": 25,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-4d24b4",
-    "o-768300"
+    "06d62c00a607b83c",
+    "7581b4d8947de730"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7920,15 +7920,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-1a8dba": 1,
-       "o-4d24b4": -2,
-       "o-768300": -5,
-       "o-7a5dad": 1,
-       "o-80e544": 1,
-       "o-ce0b06": 1,
-       "o-dfd23e": 1,
-       "o-eff95f": 1,
-       "o-f0f244": 1
+       "06d62c00a607b83c": -5,
+       "472d1e7889934f9f": 1,
+       "56f1b9881437945e": 1,
+       "61af6215f6091076": 1,
+       "72a8074535d36672": 1,
+       "7581b4d8947de730": -2,
+       "75e76b6ea7023c4a": 1,
+       "aa979f9a1412318e": 1,
+       "f6f9581a7e4ac64a": 1
       }
      }
     }
@@ -7942,17 +7942,17 @@
    "n_flipped_items": 15,
    "n_lid_biting_flips": 11,
    "lid_biting_items": [
-    "o-453b5d95b88e",
-    "r-0f086fe5c010",
-    "r-331326c75def",
-    "r-88059dfbd588",
-    "r-997f8f02f3cb",
-    "r-b67485a18295",
-    "s-0b48ef1cb43e",
-    "s-899ade68a15f",
-    "s-c66dcbba4e89",
-    "s-ce5ce485b0f0",
-    "s-e955a5f0fd3f"
+    "0679c1e2ae651680",
+    "1c3bb881bbae48cf",
+    "1e7de2d3e6a17795",
+    "30868cb3707fc34b",
+    "45fce29f9a7bd900",
+    "49ec937ca311decc",
+    "8262b52a61a8c467",
+    "82b3d6060030c170",
+    "94c519d9f761b862",
+    "b86ee5314af13042",
+    "e7ac9c97fbb81276"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -7988,9 +7988,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0ecf82cb8f13": 1,
-       "o-453b5d95b88e": -2,
-       "o-e8a6960b453d": 1
+       "b86ee5314af13042": -2,
+       "b98e1bf497da1b59": 1,
+       "c36cdc2bfcc632a0": 1
       }
      }
     },
@@ -8006,30 +8006,30 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-052ba0797573": 4,
-       "s-0b48ef1cb43e": -9,
-       "s-1aaa8c07ef26": 1,
-       "s-2836c5dbfe37": 1,
-       "s-2ced6861f01c": 1,
-       "s-36fe5942296e": 3,
-       "s-3d957fd57e2d": 4,
-       "s-4a642e727dad": 3,
-       "s-59224135f174": 2,
-       "s-69ecac1ede8d": 1,
-       "s-74545b358383": 3,
-       "s-7ab2c5c3c550": 4,
-       "s-7ead4ecaa6af": 1,
-       "s-801c4f6bc974": 4,
-       "s-899ade68a15f": -5,
-       "s-9bd86e95a948": 1,
-       "s-a7ee6f6e2658": 1,
-       "s-c66dcbba4e89": -10,
-       "s-ce5ce485b0f0": -8,
-       "s-d151f729e7c0": 1,
-       "s-d831217665a4": 3,
-       "s-e955a5f0fd3f": -9,
-       "s-eed2a5844d05": 2,
-       "s-f39ea24f609f": 1
+       "03b85b348ae39bde": 1,
+       "1c3bb881bbae48cf": -5,
+       "1e7de2d3e6a17795": -10,
+       "30868cb3707fc34b": -8,
+       "337798fbcddc5c4b": 1,
+       "35c0009c9e9db3cd": 1,
+       "4195dc17493c5621": 3,
+       "4ae47d1f21710812": 2,
+       "57b3c25766500548": 1,
+       "57c45f31a7284552": 1,
+       "5e043d0e384e7b10": 1,
+       "796d7b49d67cf1a2": 3,
+       "7a904560954aad4e": 4,
+       "8124cabb66590cf3": 4,
+       "8262b52a61a8c467": -9,
+       "86c8b642af972666": 4,
+       "8a337fe4d5550ab0": 1,
+       "94c519d9f761b862": -9,
+       "aab6d0952c548c82": 1,
+       "bbc78f37b198c4bd": 2,
+       "bcd24263f3532cf2": 3,
+       "dfe9114f4382ede2": 4,
+       "e79e93541780c6ed": 1,
+       "ed714e5f1b1759c5": 3
       }
      }
     }
@@ -8043,10 +8043,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "h:88ec9ba7d4f8",
-    "r-079cd2f13594",
-    "s-33c9eca870b0",
-    "s-44bea15d48e3"
+    "27ba41129839f014",
+    "7e1161199e9f8b2a",
+    "9bcfbc842c86dfe7",
+    "da359ebf73688ab4"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8080,11 +8080,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0426d41a4189": 1,
-       "s-17c8da86bb23": 1,
-       "s-33c9eca870b0": -2,
-       "s-44bea15d48e3": -1,
-       "s-844f06aef8bb": 1
+       "3dab0dd5a7f26746": 1,
+       "7e1161199e9f8b2a": -2,
+       "9bcfbc842c86dfe7": -1,
+       "aeaf9803ce72639d": 1,
+       "e38ffe1fd65e02d5": 1
       }
      }
     }
@@ -8098,10 +8098,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-684deac31fed",
-    "r-adefff38636c",
-    "s-595568e69baa",
-    "s-87e9485d2ab7"
+    "1a51d41befabeba5",
+    "7f6635da6029c200",
+    "9ce566ee26291a13",
+    "d325fd1dc2e65cef"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8129,14 +8129,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3c0eaf620489": 2,
-       "s-595568e69baa": -6,
-       "s-62b9807c3d57": 2,
-       "s-726978e3ea4d": 1,
-       "s-82e4d653597a": 2,
-       "s-87e9485d2ab7": -5,
-       "s-abb895fbfbb8": 2,
-       "s-ed74f28e357f": 2
+       "1a51d41befabeba5": -5,
+       "1afe33255a7b0b48": 2,
+       "2ad2e94610328c47": 2,
+       "4eaa8131a69ef71d": 2,
+       "6d3d219ce7cd6131": 2,
+       "7f6635da6029c200": -6,
+       "dc23046740b0f85f": 2,
+       "f2570015bb9e32b6": 1
       }
      }
     }
@@ -8150,13 +8150,13 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-09c21907af19",
-    "r-38b92d2606b4",
-    "s-7c9f02c074eb",
-    "s-c01ed5543f1d",
-    "s-e767e986fb17",
-    "s-f92064d36d78",
-    "s-ffa146d02207"
+    "07460b11473b9596",
+    "0a38de1846ef7b5e",
+    "5d63d9af1312fa50",
+    "708b7e9b6b88af83",
+    "7d87990be1ac4493",
+    "83255d296f1fa940",
+    "8adcb52c845f169d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8188,28 +8188,28 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2f6e8d6d6ca9": 5,
-       "s-34d04bff18b5": 4,
-       "s-4a3e427ba574": 5,
-       "s-4ba477f11dc7": 4,
-       "s-5977c9a9db5e": 5,
-       "s-69702a7b7eab": 5,
-       "s-7c9f02c074eb": -14,
-       "s-882c1bdd124c": 5,
-       "s-8ecf8fc92a08": 1,
-       "s-9975af4e33e2": 1,
-       "s-9dbecff3a129": 5,
-       "s-ade14442f07e": 4,
-       "s-ae6464b10546": 5,
-       "s-c01ed5543f1d": -12,
-       "s-c3f3f9422351": 5,
-       "s-cf7860c6f9b8": 5,
-       "s-d2862b613d85": 5,
-       "s-e767e986fb17": -14,
-       "s-e816441e20ff": 5,
-       "s-e86ac5047019": 1,
-       "s-f92064d36d78": -14,
-       "s-ffa146d02207": -16
+       "051b07853a97f9e0": 1,
+       "0a38de1846ef7b5e": -14,
+       "1d9a648dba2636d6": 5,
+       "22868829a1b02335": 5,
+       "38f86aef8f7b015a": 4,
+       "44792132e7011452": 5,
+       "5a18700c39700be2": 5,
+       "5d63d9af1312fa50": -16,
+       "62356b97f705f761": 5,
+       "635d9d7e2c9a3d35": 5,
+       "695f9eeb95d48fc5": 4,
+       "6c082c1a89f01764": 5,
+       "708b7e9b6b88af83": -12,
+       "745235d79f8a20f2": 5,
+       "7d87990be1ac4493": -14,
+       "83255d296f1fa940": -14,
+       "91ad7f815cf0dac0": 5,
+       "a3ff1aea2d2674fd": 5,
+       "bd9c76469e3fbd51": 1,
+       "e4df77a71255e1a5": 1,
+       "eff7aba1c43b7cd7": 4,
+       "fe685ff754f6f812": 5
       }
      }
     }
@@ -8223,8 +8223,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-68cac233fb7d",
-    "s-8c81bb82ca15"
+    "476ed56303cc07e5",
+    "a92ca8643cb7bfde"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8252,9 +8252,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3f451d1a34cb": 2,
-       "s-68cac233fb7d": -1,
-       "s-8c81bb82ca15": -1
+       "0b607aa6d399abb0": 2,
+       "476ed56303cc07e5": -1,
+       "a92ca8643cb7bfde": -1
       }
      }
     }
@@ -8268,15 +8268,15 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "o-8f20cc8abd02",
-    "r-13bf917d5096",
-    "r-1f22649ae343",
-    "r-961582eeea75",
-    "s-42a72a9e2b68",
-    "s-a0426f1276c1",
-    "s-e450ca545652",
-    "s-fac006c061d9",
-    "u-8fc28b26d292"
+    "105dd88867e048cf",
+    "16b0a53115aef84c",
+    "2c768323a51506cb",
+    "6f60a655655f9797",
+    "7149fd97447f8e09",
+    "84df221d61b80b1f",
+    "ac16c5d68d16f82d",
+    "f64f01ce80462c59",
+    "feeb3791baa51576"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8310,12 +8310,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0d70a0faec82": 1,
-       "o-5c5f41a2c690": 1,
-       "o-8f20cc8abd02": -5,
-       "o-9aca4299a9fc": 1,
-       "o-bb09bc046fee": 1,
-       "o-ce7a425f9d29": 1
+       "07f4554681e79ea0": 1,
+       "0a5eadf4da1c28dd": 1,
+       "486e876a16f0a130": 1,
+       "63100fd35d55fabe": 1,
+       "dfab68aa0c6a5960": 1,
+       "feeb3791baa51576": -5
       }
      }
     },
@@ -8331,23 +8331,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0aeb3fc503a6": 3,
-       "s-21279c24c69d": 2,
-       "s-42a72a9e2b68": -11,
-       "s-45561dac93e0": 3,
-       "s-6594c825b4c3": 2,
-       "s-9b81373f9e84": 3,
-       "s-a0426f1276c1": -3,
-       "s-a8cffa3b8675": 2,
-       "s-ab395a28fa44": 1,
-       "s-c5a56819ee9a": 1,
-       "s-c6f05449f3a9": 4,
-       "s-d96d60f5ef22": 2,
-       "s-e450ca545652": -6,
-       "s-e4cdb1e76574": 3,
-       "s-eb51bdae3031": 3,
-       "s-f6280aa1bb67": 2,
-       "s-fac006c061d9": -11
+       "0b4832e259fd873a": 3,
+       "105dd88867e048cf": -3,
+       "15f9d2d2cfd79959": 2,
+       "16b0a53115aef84c": -11,
+       "1f6a745ea25e2ee9": 1,
+       "3d75f5968b7b31a3": 3,
+       "677752ba154716ba": 3,
+       "7149fd97447f8e09": -11,
+       "79c278e878c0becf": 3,
+       "837e807cfe6ca80f": 2,
+       "9109a5d5cbb13756": 2,
+       "9d6d8dd762c46a48": 4,
+       "aaa8ac19f087a2b0": 3,
+       "ac16c5d68d16f82d": -6,
+       "c828f28c3bb4fbbb": 2,
+       "d90719ee5c6a16a8": 2,
+       "de1e9529b37bd988": 1
       }
      }
     },
@@ -8363,8 +8363,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-8fc28b26d292": -1,
-       "u-c1578ef88cc1": 1
+       "3036365cd71c75b5": 1,
+       "6f60a655655f9797": -1
       }
      }
     }
@@ -8378,13 +8378,13 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-0d5fc1bf6aa9",
-    "r-3bbedef5cafd",
-    "r-ac80adb8ecc8",
-    "r-bd4e38b05528",
-    "s-65e8c18f4ac9",
-    "s-b1ec0eb426b5",
-    "s-c6c616fdc5b3"
+    "0e662fd541b7a2a2",
+    "280e1ed9aa91407f",
+    "412b02ddb1ed97b2",
+    "4458dbb5876f5898",
+    "45c1e55f0e27084a",
+    "a6d54258145a7787",
+    "e06ee07d63e345f6"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8418,14 +8418,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-036dcc47f9e4": 1,
-       "s-288a58118486": 2,
-       "s-292fc2d66cde": 3,
-       "s-65e8c18f4ac9": -4,
-       "s-85e2f6488321": 3,
-       "s-a527ebf16eb4": 3,
-       "s-b1ec0eb426b5": -4,
-       "s-c6c616fdc5b3": -4
+       "280e1ed9aa91407f": -4,
+       "412b02ddb1ed97b2": -4,
+       "48e4e7597d1852ba": 3,
+       "756d863d68b55589": 3,
+       "a6d54258145a7787": -4,
+       "a734f5dad8caedab": 1,
+       "d34adedb69a78705": 3,
+       "e92aff590974b18e": 2
       }
      }
     }
@@ -8439,11 +8439,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "h:27736e92e6e1",
-    "o-8d8ae223d83e",
-    "r-41c555a1df1e",
-    "s-ce89d202fa83",
-    "s-d9af82ba3853"
+    "2a5d68b8bda1f3cc",
+    "990c064af022e30d",
+    "b1590ae2dab491a7",
+    "d1d366dd04e1f781",
+    "ff3013b189ecaed3"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8475,8 +8475,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2c3bf6e39430": 1,
-       "o-8d8ae223d83e": -1
+       "074d50098689ee85": 1,
+       "990c064af022e30d": -1
       }
      }
     },
@@ -8492,10 +8492,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-201e63869049": 2,
-       "s-afa963ca3cc0": 2,
-       "s-ce89d202fa83": -2,
-       "s-d9af82ba3853": -2
+       "40bebedc6d23bac7": 2,
+       "d1d366dd04e1f781": -2,
+       "e1cb4a29e6a57257": 2,
+       "ff3013b189ecaed3": -2
       }
      }
     }
@@ -8509,10 +8509,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-d85fe2b8abb0",
-    "s-4ef4f0bf8804",
-    "s-c65ef1638f19",
-    "s-f3ff4b52f452"
+    "7000b94f221d4735",
+    "8a4d38f8a45ca9d7",
+    "ca56ccd37cb607a1",
+    "f61e9308b53ced5d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8544,15 +8544,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3379c0e36d6e": 3,
-       "s-43ef8115dc97": 3,
-       "s-4ef4f0bf8804": -6,
-       "s-5f14a2642360": 3,
-       "s-67543ed036ae": 3,
-       "s-7b919d0f115a": 3,
-       "s-b6b42a4409c6": 3,
-       "s-c65ef1638f19": -6,
-       "s-f3ff4b52f452": -6
+       "2e526d71e40f8024": 3,
+       "33d8c2b91e741aa2": 3,
+       "39d18dd8e6f82d03": 3,
+       "5cccdb0f82c2d1ae": 3,
+       "7000b94f221d4735": -6,
+       "8a4d38f8a45ca9d7": -6,
+       "e8248858d6b8143e": 3,
+       "f61e9308b53ced5d": -6,
+       "fe0a747699277a0e": 3
       }
      }
     }
@@ -8566,8 +8566,8 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-9ffbee5798e2",
-    "s-f5a66545e46f"
+    "658b911fb3d654c1",
+    "a0e6aeb5541c9f39"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8601,13 +8601,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-10a1241589cb": 1,
-       "s-49bdee52c240": 1,
-       "s-72c4ac7c61b8": 1,
-       "s-992c31c47599": 1,
-       "s-9f086aa4df71": 1,
-       "s-e98ee41cacad": 1,
-       "s-f5a66545e46f": -6
+       "05e5878d84ca617c": 1,
+       "11576d7756e55413": 1,
+       "328d49dbc7e8731c": 1,
+       "40ea0f339aa2a2bd": 1,
+       "51bb6a1e1db16b90": 1,
+       "6a27499c7e4f2664": 1,
+       "a0e6aeb5541c9f39": -6
       }
      }
     }
@@ -8621,30 +8621,30 @@
    "n_flipped_items": 32,
    "n_lid_biting_flips": 24,
    "lid_biting_items": [
-    "r-05383bc237ec",
-    "r-659c3e1ad736",
-    "r-68ed04e46409",
-    "r-740d09e38b73",
-    "r-744ad8a7e32e",
-    "r-77bed82f42e1",
-    "r-7c7cc711d76a",
-    "r-8711d40f0a8f",
-    "r-991abd7eddca",
-    "r-b8d61526ecbe",
-    "r-ece2154ffc3f",
-    "r-f0d011f0cf0b",
-    "s-0ebf14df31bd",
-    "s-4e2ea3f7f26e",
-    "s-54c591dda7f0",
-    "s-68cc0f5bc2d3",
-    "s-87cf59f5ddfd",
-    "s-8bb737f3fc5c",
-    "s-92df778b5f26",
-    "s-ad1966907004",
-    "s-adc641707a9e",
-    "s-b4079f5a9872",
-    "s-e95495b6eaae",
-    "s-f792ee76b83d"
+    "04b8dcae11ce8757",
+    "0b5409ac27d138dc",
+    "0c9443f1b87730ce",
+    "19430ad323838f57",
+    "243bb0c3b0672e20",
+    "2fb5908d960846cb",
+    "5f1692649c049908",
+    "6ecdcce426b5bf48",
+    "742a7eacdc53aef0",
+    "79947916d1add0b4",
+    "8f4cbcbe6df1c205",
+    "90b14084a5988bf3",
+    "b14829d42ae3fbd9",
+    "bc6d99017eeb76c4",
+    "bcd9ae97e6e44f8a",
+    "cb0ec1f94b43f1d5",
+    "dd7916d6154abb79",
+    "de1cfa6708f5d6d1",
+    "de9249c512acae6b",
+    "e04f1435fe543ac6",
+    "e8b2a5f6ee8dc039",
+    "ee5eafd1af7fccd7",
+    "f111742ac757a83d",
+    "f448a1170720287e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8680,45 +8680,45 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0ebf14df31bd": -18,
-       "s-10236c7fa784": 11,
-       "s-12bd4319abe9": 7,
-       "s-1d596b280201": 9,
-       "s-258383cb3435": 11,
-       "s-363bedccbc09": 10,
-       "s-37f62fd03732": 7,
-       "s-384f000c89e6": 5,
-       "s-3a6220055085": 6,
-       "s-3e9a3840549a": 12,
-       "s-47a263e0668c": 1,
-       "s-4c6f3b2484cf": 5,
-       "s-4e2ea3f7f26e": -11,
-       "s-5012d55bff81": 7,
-       "s-54c591dda7f0": -12,
-       "s-5654ac5eed88": 5,
-       "s-6169ba5b4420": 6,
-       "s-681d85b90569": 6,
-       "s-68cc0f5bc2d3": -9,
-       "s-6f68de3ea13d": 7,
-       "s-7043053c7d72": 6,
-       "s-86fb2b72ca7f": 7,
-       "s-87cf59f5ddfd": -18,
-       "s-8bb737f3fc5c": -18,
-       "s-8d57bd08bdde": 6,
-       "s-92df778b5f26": -17,
-       "s-98c5c6598e59": 10,
-       "s-9aadccbf4e1e": 6,
-       "s-a8f631cf31bd": 7,
-       "s-ad1966907004": -17,
-       "s-adc641707a9e": -11,
-       "s-b4079f5a9872": -12,
-       "s-ba1f7c349db5": 7,
-       "s-d884706b10f5": 1,
-       "s-e704f3608059": 2,
-       "s-e95495b6eaae": -18,
-       "s-f792ee76b83d": -19,
-       "s-f7cb0da239c8": 6,
-       "s-f8022b92f5fa": 7
+       "08bf1725c0d0ed0b": 10,
+       "0bd5329d0a0350d7": 9,
+       "128d250113f61b2e": 7,
+       "1949165f36489710": 7,
+       "23b20b51718fa711": 2,
+       "243bb0c3b0672e20": -11,
+       "2fb5908d960846cb": -11,
+       "31a25936d261ed4c": 5,
+       "3284111442ac4a25": 6,
+       "336a83c6d4637718": 12,
+       "34d403f6f8f95459": 6,
+       "4259f9422ad95033": 7,
+       "56d32fa06f0298c0": 6,
+       "5b82a41cbdf414b9": 1,
+       "5b9dbed415f1088d": 6,
+       "5f1692649c049908": -18,
+       "66e088e1a271b2c0": 11,
+       "68f7e470a1f0454f": 1,
+       "742a7eacdc53aef0": -19,
+       "790166ed4082e1c2": 6,
+       "8cfa148ad3acb922": 7,
+       "8f4cbcbe6df1c205": -18,
+       "9a9e25e5c36276bd": 7,
+       "a9c7ec4c8b7ea1e2": 7,
+       "b09c55a826f60584": 10,
+       "b14829d42ae3fbd9": -12,
+       "bcd9ae97e6e44f8a": -18,
+       "c1681f99655a032d": 6,
+       "c1d9650f8acaf79f": 11,
+       "c6b8f8b9617b00da": 6,
+       "cb0ec1f94b43f1d5": -17,
+       "d7fc9977b5600894": 7,
+       "de1cfa6708f5d6d1": -9,
+       "e04f1435fe543ac6": -12,
+       "e8b2a5f6ee8dc039": -18,
+       "ee5eafd1af7fccd7": -17,
+       "efd56e4778454551": 7,
+       "f25ce085b5599f50": 5,
+       "f2b89b3571311911": 5
       }
      }
     }
@@ -8732,11 +8732,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-0511fdb5aa9e",
-    "r-27305c811587",
-    "r-6115e622fea8",
-    "r-f2dd9a43b0fc",
-    "s-d0e267ac9ce2"
+    "0c6d620978ce8459",
+    "30b7cb322b5b12ff",
+    "ad49e0f07e2c13e8",
+    "e13312ef792aa106",
+    "e96fd00d1a067243"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8770,16 +8770,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-16ed9cfa058d": 1,
-       "s-272f43dc4937": 1,
-       "s-3597c0d8ddd7": 1,
-       "s-445b1a77d717": 1,
-       "s-46dcfeb667bf": 1,
-       "s-4ea5ee488511": 1,
-       "s-c0bd50089442": 1,
-       "s-cf2cbb547fa9": 1,
-       "s-d0e267ac9ce2": -9,
-       "s-e1d805646990": 1
+       "30b7cb322b5b12ff": -9,
+       "76554485c88cbdce": 1,
+       "83e9239d9f7261be": 1,
+       "89de7c88017762c6": 1,
+       "9b91a590bd1ebf41": 1,
+       "a64523b6c0515e2a": 1,
+       "b2c74bc924bb6db4": 1,
+       "c0c2bf120b0444f0": 1,
+       "dc1d9924f4f9650f": 1,
+       "f4afb62aaec68da1": 1
       }
      }
     }
@@ -8793,11 +8793,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-71210f26306a",
-    "r-af3e94156daa",
-    "s-0f5136d3bf42",
-    "s-4e278822421f",
-    "s-b26796275ac5"
+    "0725caee5638d68d",
+    "29616f7488190bfc",
+    "33049d8eda64e590",
+    "3b1041067b5ce59e",
+    "9a2dd08b559e5488"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8831,18 +8831,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0f5136d3bf42": -5,
-       "s-4bdafe86f02d": 3,
-       "s-4ceb0cd2f1b1": 3,
-       "s-4e278822421f": -4,
-       "s-53ccc9a9a7ce": 2,
-       "s-6f3736d1c493": 1,
-       "s-78afd13558ef": 1,
-       "s-b26796275ac5": -8,
-       "s-c1d686f823da": 3,
-       "s-e193834c33b9": 1,
-       "s-ec826a951811": 2,
-       "s-ffa9b87904cd": 1
+       "0725caee5638d68d": -5,
+       "09dc5b0bca9e9995": 1,
+       "0d918955baa5a370": 1,
+       "2781aae1a13c663d": 2,
+       "2b0df2d761aad9be": 3,
+       "33049d8eda64e590": -4,
+       "376e8428add8095c": 3,
+       "48ad17d1b325caf9": 1,
+       "4aa585f931a791b3": 3,
+       "502ff0d07a7e9687": 2,
+       "5f8dcbf9bca405f4": 1,
+       "9a2dd08b559e5488": -8
       }
      }
     }
@@ -8856,16 +8856,16 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "o-02fbc7",
-    "o-552494",
-    "o-5a1bf2",
-    "o-ecd6e7",
-    "r-0026d2",
-    "r-507507",
-    "r-521279",
-    "r-9f4bc7",
-    "r-bec885",
-    "s-f6cbf2"
+    "3252f9fccd5666ad",
+    "3a5d7b9688ac0816",
+    "4a867abb5edb18b4",
+    "6c9b5b3dfcd4e24a",
+    "744b4c9c8ea27e7e",
+    "776a5a4e7436abf6",
+    "889f727c81e9ffa3",
+    "c5e14304a7414f49",
+    "dd201525732b033f",
+    "f60c60c9f1e48159"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8899,19 +8899,19 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-02fbc7": -9,
-       "o-1e946b": 4,
-       "o-251534": 4,
-       "o-29cef2": 4,
-       "o-552494": -9,
-       "o-5a1bf2": -9,
-       "o-7dc360": 4,
-       "o-8c0397": 4,
-       "o-9f2e03": 4,
-       "o-ce8dda": 4,
-       "o-d376b9": 4,
-       "o-e68997": 4,
-       "o-ecd6e7": -9
+       "182afbf49e719ddc": 4,
+       "20d6b8a75cc406ef": 4,
+       "2db3a102a296f29c": 4,
+       "31c521b18fd4e0f1": 4,
+       "3252f9fccd5666ad": -9,
+       "348c72d4776fb12b": 4,
+       "6187cb1a3f32c8d6": 4,
+       "6514cb26eaa0c90b": 4,
+       "6c9b5b3dfcd4e24a": -9,
+       "776a5a4e7436abf6": -9,
+       "909122f2879e34c4": 4,
+       "9f075afdf6bac094": 4,
+       "c5e14304a7414f49": -9
       }
      }
     },
@@ -8927,11 +8927,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6036c6": 1,
-       "s-7585c1": 1,
-       "s-91de60": 1,
-       "s-f6cbf2": -4,
-       "s-fb1b10": 1
+       "0f762ef175c8ef47": 1,
+       "19eb67ef909c9727": 1,
+       "4a867abb5edb18b4": -4,
+       "77b0f30ac1af9eaf": 1,
+       "f9d0764804c8eef4": 1
       }
      }
     }
@@ -8945,10 +8945,10 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-02fbc7",
-    "o-552494",
-    "o-5a1bf2",
-    "o-ecd6e7"
+    "3252f9fccd5666ad",
+    "6c9b5b3dfcd4e24a",
+    "776a5a4e7436abf6",
+    "c5e14304a7414f49"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -8982,12 +8982,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-02fbc7": -2,
-       "o-552494": -2,
-       "o-5a1bf2": -2,
-       "o-8c0397": 4,
-       "o-9f2e03": 4,
-       "o-ecd6e7": -2
+       "20d6b8a75cc406ef": 4,
+       "3252f9fccd5666ad": -2,
+       "6c9b5b3dfcd4e24a": -2,
+       "776a5a4e7436abf6": -2,
+       "9f075afdf6bac094": 4,
+       "c5e14304a7414f49": -2
       }
      }
     }
@@ -9001,15 +9001,15 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "r-03fc47c08c7f",
-    "r-0ec10200d939",
-    "r-123e2fca6dfa",
-    "r-1bbf41467f00",
-    "r-8ffef3f71752",
-    "r-ec56d70c766b",
-    "s-403c667572aa",
-    "s-5d7f5bfb93b1",
-    "s-f3d17a821e40"
+    "04795ee1dec06b4a",
+    "27a0972798f69dfa",
+    "402b4008c5b9dd07",
+    "4e7516e9f01d0b28",
+    "6faf56c535d106a4",
+    "8ad51fc58c372c85",
+    "8ebbb06613d094b7",
+    "c83a5842cc0caeca",
+    "e7c88f722d691721"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9043,21 +9043,21 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0375e0fd1a8b": 1,
-       "s-2a42dde71b54": 2,
-       "s-2b321cc70ff8": 1,
-       "s-400184dc4d43": 1,
-       "s-403c667572aa": -7,
-       "s-508912118d9b": 2,
-       "s-5d7f5bfb93b1": -7,
-       "s-7f21c3f55b6f": 3,
-       "s-83168a007e1e": 1,
-       "s-a38658296571": 2,
-       "s-a5fa7defc695": 2,
-       "s-adc919fdfbc5": 2,
-       "s-b37b64128caa": 2,
-       "s-e8530917874b": 1,
-       "s-f3d17a821e40": -6
+       "153b88832bceab78": 3,
+       "1b6e2ddf708a0a46": 2,
+       "4452df2d2c1346e5": 2,
+       "525c16e21c99a98a": 2,
+       "6faf56c535d106a4": -7,
+       "72e3423f0f01c52f": 2,
+       "75ca8d9b3b0a387f": 1,
+       "8ad51fc58c372c85": -6,
+       "8ebbb06613d094b7": -7,
+       "ac7517a0ac5d0e9c": 1,
+       "ae2c1cc28e9881d7": 1,
+       "cf4ab0f078000182": 2,
+       "d1f72f61bc403837": 1,
+       "e66fbca4821a9205": 1,
+       "ee3f81b7f38de03e": 2
       }
      }
     }
@@ -9071,17 +9071,17 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 11,
    "lid_biting_items": [
-    "h:3b12ddf72b64",
-    "o-fcaa54",
-    "r-158a6e",
-    "r-2f9c0b",
-    "r-56a249",
-    "r-895ca6",
-    "r-f5da55",
-    "s-163485",
-    "s-60416b",
-    "s-7129bd",
-    "s-bbb887"
+    "03fb430d55d3e626",
+    "0bf747e877e521a0",
+    "3fcffb43b3b6388f",
+    "44f4e492bb906831",
+    "799194daf1bae261",
+    "81e89bde1de2afd3",
+    "85121181e7732f33",
+    "a4912709794e9d55",
+    "a7b3573d588ccde6",
+    "bacda44e780f40ea",
+    "ef2ae4c87b5087b2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9113,9 +9113,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-40deea": 1,
-       "o-f7df21": 1,
-       "o-fcaa54": -2
+       "44f4e492bb906831": -2,
+       "889552c242f4d039": 1,
+       "bafc3fe1e39c3049": 1
       }
      }
     },
@@ -9124,10 +9124,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-982a09"
+       "b0395602bb7c40d1"
       ],
       "only_ungated": [
-       "s-60416b"
+       "03fb430d55d3e626"
       ]
      },
      "rank_diff": {
@@ -9135,18 +9135,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-163485": -8,
-       "s-2a8d29": 2,
-       "s-34785b": 4,
-       "s-373190": 2,
-       "s-449b4a": 4,
-       "s-4a2f20": 2,
-       "s-60416b": -4,
-       "s-7129bd": -8,
-       "s-75aefc": 2,
-       "s-982a09": 4,
-       "s-bbb887": -4,
-       "s-e5085d": 4
+       "03fb430d55d3e626": -4,
+       "6858896531d688d9": 4,
+       "6960b9a7187e7b1a": 2,
+       "6e77c69f6ac6e4f1": 4,
+       "799194daf1bae261": -4,
+       "7c1fadf46490c84d": 2,
+       "a4912709794e9d55": -8,
+       "b0395602bb7c40d1": 4,
+       "c518334d70b89431": 2,
+       "cfbf078ebd1e16c6": 2,
+       "ece1ce686e88b4f9": 4,
+       "ef2ae4c87b5087b2": -8
       }
      }
     }
@@ -9160,12 +9160,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-058062",
-    "r-399ef0",
-    "r-8398ed",
-    "r-88b886",
-    "r-ecb68d",
-    "s-42fdb2"
+    "174a4c9724e75457",
+    "1d4d56099fa13fa9",
+    "22501d59fcc7e730",
+    "795a83a1b3c28e02",
+    "97b6a7e263d2b10a",
+    "a6181d0c3387c5e8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9193,11 +9193,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-090bbb": 1,
-       "s-42fdb2": -4,
-       "s-87e23c": 1,
-       "s-b846d7": 1,
-       "s-e8fc14": 1
+       "230ad23da9d39843": 1,
+       "28bf3d27422c223b": 1,
+       "97b6a7e263d2b10a": -4,
+       "ddc45aeb08d76d2f": 1,
+       "e253d6111b55b251": 1
       }
      }
     }
@@ -9211,14 +9211,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "h:137d835f6ad1",
-    "o-9896d439ee20",
-    "r-787e35403437",
-    "r-b22836594baf",
-    "r-e9dacdbeeb8d",
-    "s-0f5d1d3f6d88",
-    "s-61805f9f1f97",
-    "s-d29fd17372eb"
+    "395a66ad553aa4b6",
+    "408655fb20f135d2",
+    "41fc50e1c4cf55c4",
+    "5dec43b5f48f8e15",
+    "6f0af463198645f5",
+    "7680578f6f779107",
+    "9f18502978c190ae",
+    "e24bcec7a0f45f4c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9246,19 +9246,19 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-090017849a1d": 2,
-       "s-0c72f3991afa": 2,
-       "s-0f5d1d3f6d88": -2,
-       "s-1f4bda9373c2": 2,
-       "s-4005e638d404": 2,
-       "s-436436919bca": 1,
-       "s-4ccb183c0355": 2,
-       "s-5e6fff0cb580": 3,
-       "s-61805f9f1f97": -10,
-       "s-9fbe71854b5e": 2,
-       "s-c75ef13650d4": 2,
-       "s-d29fd17372eb": -9,
-       "s-e2b397d68209": 3
+       "19a7b87c77c284e2": 2,
+       "4b28e9b02244ac76": 2,
+       "5eabe66bb3254339": 3,
+       "6cf658f06b2f52be": 2,
+       "6f0af463198645f5": -9,
+       "7680578f6f779107": -2,
+       "7f68d86c10aae0c6": 2,
+       "8a37bc2228947f56": 2,
+       "8e443134d344ed2e": 2,
+       "9daeff42876ecf6a": 3,
+       "9f18502978c190ae": -10,
+       "b9e1360cd6ef87a8": 1,
+       "f9bbd8e773e0782e": 2
       }
      }
     }
@@ -9272,14 +9272,14 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-80c119",
-    "r-f8f137",
-    "r-ff2539",
-    "s-6fdbbe"
+    "2bc6c1e6b02e54ed",
+    "6b82addc2f6e52bb",
+    "891bae708c3b7da1",
+    "cdc007faa8707858"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-f8f137"
+    "cdc007faa8707858"
    ],
    "over_budget": {
     "gated": true,
@@ -9313,13 +9313,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-300414": 1,
-       "s-44d0d9": 1,
-       "s-4d1f1f": 1,
-       "s-6fdbbe": -6,
-       "s-8e1e2f": 1,
-       "s-aa0424": 1,
-       "s-c072b4": 1
+       "2677f0130fc346c0": 1,
+       "891bae708c3b7da1": -6,
+       "a7bb0a5a33de2c40": 1,
+       "a8eef9b06c9b3a74": 1,
+       "c37d1c842ec22e41": 1,
+       "d2b27b9e6d9efb20": 1,
+       "f44b24e083f0a545": 1
       }
      }
     }
@@ -9333,9 +9333,9 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-ac9059c8b7f0",
-    "s-78ac02e291a2",
-    "s-e734e4fd668f"
+    "233ca975c12e6565",
+    "5887fe235e3347b0",
+    "b5fe98e7022b9648"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9360,12 +9360,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-75924613f4c4",
-       "s-eef2ca774c29"
+       "249e31f3e0f4b6c3",
+       "4f35152c138c595d"
       ],
       "only_ungated": [
-       "s-78ac02e291a2",
-       "s-e734e4fd668f"
+       "233ca975c12e6565",
+       "b5fe98e7022b9648"
       ]
      },
      "rank_diff": {
@@ -9373,11 +9373,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-585f2775e80f": 2,
-       "s-75924613f4c4": 2,
-       "s-78ac02e291a2": -3,
-       "s-e734e4fd668f": -3,
-       "s-eef2ca774c29": 2
+       "233ca975c12e6565": -3,
+       "249e31f3e0f4b6c3": 2,
+       "4f35152c138c595d": 2,
+       "86a07634ca9e7835": 2,
+       "b5fe98e7022b9648": -3
       }
      }
     }
@@ -9391,13 +9391,13 @@
    "n_flipped_items": 13,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "o-011bcba81af5",
-    "o-4ce40097f36c",
-    "r-8c3a22923576",
-    "r-e9717c58fa8d",
-    "s-7568ac5470c1",
-    "s-bb0a376778be",
-    "s-d1d5a95e8fe0"
+    "0fcb35341933f830",
+    "18e84b7852c6fda6",
+    "b23d4e053730c33c",
+    "ba8a7a3c35047766",
+    "c9a23fe458c3ecaa",
+    "d5343d0dcfafc218",
+    "f1e6c391ba64dda5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9431,9 +9431,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-011bcba81af5": -2,
-       "o-3e074f9737d2": 1,
-       "o-55fba15a1ce4": 1
+       "ba8a7a3c35047766": -2,
+       "c9e69501791d2c22": 1,
+       "dc13a55e37c282c5": 1
       }
      }
     },
@@ -9449,9 +9449,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-4ce40097f36c": -2,
-       "o-9cd122f19243": 1,
-       "o-acfea78bf4a3": 1
+       "4195edf4febde5e5": 1,
+       "b23d4e053730c33c": -2,
+       "f337554587f19d49": 1
       }
      }
     },
@@ -9467,23 +9467,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-040d804934ea": 1,
-       "s-0751d7df2f9f": 2,
-       "s-0a6a0159862c": 1,
-       "s-3158b875cd4c": 2,
-       "s-374e1ab1f87b": 1,
-       "s-4d4cdd06e587": 2,
-       "s-7568ac5470c1": -7,
-       "s-89e2570111cc": 1,
-       "s-a133f017de62": 2,
-       "s-a5e1d284616e": 1,
-       "s-b27e81b9f718": 2,
-       "s-b61d74a8027e": 1,
-       "s-bb0a376778be": -7,
-       "s-c22718fc2939": 2,
-       "s-cad38ada2088": 2,
-       "s-d1d5a95e8fe0": -7,
-       "s-ea70876077a3": 1
+       "0fcb35341933f830": -7,
+       "18e84b7852c6fda6": -7,
+       "19657411677398ec": 2,
+       "2521b1187d588331": 2,
+       "279b1b5a32ccf7fd": 1,
+       "5a6f2960d95f116c": 2,
+       "7e3de45b2de052dd": 2,
+       "8ec0d07e147de26c": 1,
+       "a3d24cb1eb218287": 1,
+       "a621e40bc55d3399": 1,
+       "a63a7abb3612c9e5": 2,
+       "a7ac14eb73e3757c": 2,
+       "b64af0a96f9ba074": 1,
+       "bbb853ed8b1a5d7b": 1,
+       "c9a23fe458c3ecaa": -7,
+       "e649dea13d888cd5": 1,
+       "eab7e5750bdd51ba": 2
       }
      }
     }
@@ -9497,27 +9497,27 @@
    "n_flipped_items": 22,
    "n_lid_biting_flips": 21,
    "lid_biting_items": [
-    "o-dd1caa16cd8a",
-    "o-f4019385e73b",
-    "r-46a85d1a24ef",
-    "r-4e52fb0a74b2",
-    "r-5daec414e0dc",
-    "r-5e4c2d16cd6c",
-    "r-63313854e9ec",
-    "r-6dc3a8c0fdcd",
-    "r-842a8df138ec",
-    "r-909ea94bbfe8",
-    "r-ad616bc70b9f",
-    "r-b718cddce271",
-    "r-b8566a08e1bf",
-    "r-d5792e2799e4",
-    "r-d6afcb1c2234",
-    "r-e5a0896265bd",
-    "r-ea53cfc150ff",
-    "r-ed106edfbe7a",
-    "s-39924fced401",
-    "s-9ba17f97f8d6",
-    "s-e323c8b33550"
+    "27a510edf81893f4",
+    "37b77a10f0cd2f33",
+    "3e0b7661a00c7248",
+    "437296918d707c33",
+    "4c2a2a1e3c548b13",
+    "5280f7d6e941568d",
+    "565bba569802eb8f",
+    "5860f43167d50368",
+    "6d62c43b4655e201",
+    "75d949346f9368a2",
+    "94187ddc745adc70",
+    "9ba6a3cf03cdba37",
+    "b4e4b692b882900e",
+    "b5451be54eea14b1",
+    "ca73f6663d6a7fab",
+    "d51ce0f8eb2a03eb",
+    "df93bb9e815d103f",
+    "e47ca24f9b9fcd85",
+    "f0b24ccdcce1997a",
+    "fdfe0dcd61181450",
+    "feb0439efaa86454"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9549,10 +9549,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-bdb1ece5cdfc": 1,
-       "o-cdbf6b49844b": 2,
-       "o-dd1caa16cd8a": -1,
-       "o-f4019385e73b": -2
+       "574dfcaa8023cdb1": 1,
+       "66e575a7a3303383": 2,
+       "b4e4b692b882900e": -1,
+       "df93bb9e815d103f": -2
       }
      }
     },
@@ -9561,15 +9561,15 @@
      "cap_crossings": {
       "count": 7,
       "only_gated": [
-       "s-248e07f0a51c",
-       "s-548e6bee80e3",
-       "s-b4ed1b2c7745",
-       "s-e8495edec4eb"
+       "02b664f0aae71118",
+       "06e4ab1f04195f08",
+       "9530a5f1162df26e",
+       "b4afbf8cf5a1ce3c"
       ],
       "only_ungated": [
-       "s-39924fced401",
-       "s-9ba17f97f8d6",
-       "s-e323c8b33550"
+       "27a510edf81893f4",
+       "437296918d707c33",
+       "fdfe0dcd61181450"
       ]
      },
      "rank_diff": {
@@ -9577,16 +9577,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-248e07f0a51c": 3,
-       "s-39924fced401": -7,
-       "s-4868cf19373c": 3,
-       "s-548e6bee80e3": 3,
-       "s-9ba17f97f8d6": -7,
-       "s-b4ed1b2c7745": 3,
-       "s-b68f7f87c02c": 3,
-       "s-bcc1ebb704c3": 3,
-       "s-e323c8b33550": -7,
-       "s-e8495edec4eb": 3
+       "02b664f0aae71118": 3,
+       "06e4ab1f04195f08": 3,
+       "2060d68e9e38147b": 3,
+       "27a510edf81893f4": -7,
+       "437296918d707c33": -7,
+       "8ec7cd623c990b16": 3,
+       "9530a5f1162df26e": 3,
+       "b4afbf8cf5a1ce3c": 3,
+       "de92fd171a83920d": 3,
+       "fdfe0dcd61181450": -7
       }
      }
     }
@@ -9600,8 +9600,8 @@
    "n_flipped_items": 22,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-dd1caa16cd8a",
-    "o-f4019385e73b"
+    "b4e4b692b882900e",
+    "df93bb9e815d103f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9633,8 +9633,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-cdbf6b49844b": 1,
-       "o-f4019385e73b": -1
+       "66e575a7a3303383": 1,
+       "df93bb9e815d103f": -1
       }
      }
     }
@@ -9648,17 +9648,17 @@
    "n_flipped_items": 15,
    "n_lid_biting_flips": 11,
    "lid_biting_items": [
-    "o-453b5d95b88e",
-    "r-0f086fe5c010",
-    "r-331326c75def",
-    "r-88059dfbd588",
-    "r-997f8f02f3cb",
-    "r-b67485a18295",
-    "s-0b48ef1cb43e",
-    "s-899ade68a15f",
-    "s-c66dcbba4e89",
-    "s-ce5ce485b0f0",
-    "s-e955a5f0fd3f"
+    "0679c1e2ae651680",
+    "1c3bb881bbae48cf",
+    "1e7de2d3e6a17795",
+    "30868cb3707fc34b",
+    "45fce29f9a7bd900",
+    "49ec937ca311decc",
+    "8262b52a61a8c467",
+    "82b3d6060030c170",
+    "94c519d9f761b862",
+    "b86ee5314af13042",
+    "e7ac9c97fbb81276"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9694,9 +9694,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0ecf82cb8f13": 1,
-       "o-453b5d95b88e": -2,
-       "o-e8a6960b453d": 1
+       "b86ee5314af13042": -2,
+       "b98e1bf497da1b59": 1,
+       "c36cdc2bfcc632a0": 1
       }
      }
     },
@@ -9712,30 +9712,30 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-052ba0797573": 4,
-       "s-0b48ef1cb43e": -9,
-       "s-1aaa8c07ef26": 1,
-       "s-2836c5dbfe37": 1,
-       "s-2ced6861f01c": 1,
-       "s-36fe5942296e": 3,
-       "s-3d957fd57e2d": 4,
-       "s-4a642e727dad": 3,
-       "s-59224135f174": 2,
-       "s-69ecac1ede8d": 1,
-       "s-74545b358383": 3,
-       "s-7ab2c5c3c550": 4,
-       "s-7ead4ecaa6af": 1,
-       "s-801c4f6bc974": 4,
-       "s-899ade68a15f": -5,
-       "s-9bd86e95a948": 1,
-       "s-a7ee6f6e2658": 1,
-       "s-c66dcbba4e89": -10,
-       "s-ce5ce485b0f0": -8,
-       "s-d151f729e7c0": 1,
-       "s-d831217665a4": 3,
-       "s-e955a5f0fd3f": -9,
-       "s-eed2a5844d05": 2,
-       "s-f39ea24f609f": 1
+       "03b85b348ae39bde": 1,
+       "1c3bb881bbae48cf": -5,
+       "1e7de2d3e6a17795": -10,
+       "30868cb3707fc34b": -8,
+       "337798fbcddc5c4b": 1,
+       "35c0009c9e9db3cd": 1,
+       "4195dc17493c5621": 3,
+       "4ae47d1f21710812": 2,
+       "57b3c25766500548": 1,
+       "57c45f31a7284552": 1,
+       "5e043d0e384e7b10": 1,
+       "796d7b49d67cf1a2": 3,
+       "7a904560954aad4e": 4,
+       "8124cabb66590cf3": 4,
+       "8262b52a61a8c467": -9,
+       "86c8b642af972666": 4,
+       "8a337fe4d5550ab0": 1,
+       "94c519d9f761b862": -9,
+       "aab6d0952c548c82": 1,
+       "bbc78f37b198c4bd": 2,
+       "bcd24263f3532cf2": 3,
+       "dfe9114f4382ede2": 4,
+       "e79e93541780c6ed": 1,
+       "ed714e5f1b1759c5": 3
       }
      }
     }
@@ -9749,12 +9749,12 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-349daf2f93c8",
-    "s-7c169ddc2c0c"
+    "6d34b79ac2172793",
+    "7fb08ef4e87c2f73"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-349daf2f93c8"
+    "7fb08ef4e87c2f73"
    ],
    "over_budget": {
     "gated": true,
@@ -9784,11 +9784,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2ba68c2e921b": 2,
-       "s-349daf2f93c8": -3,
-       "s-7c169ddc2c0c": -3,
-       "s-80914032c356": 2,
-       "s-bf073bfb768e": 2
+       "1abc8ac2688100b2": 2,
+       "382657f6405a5e27": 2,
+       "6d34b79ac2172793": -3,
+       "7fb08ef4e87c2f73": -3,
+       "b6fdbd2f2d9a9aca": 2
       }
      }
     }
@@ -9802,7 +9802,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-0990d5"
+    "f86a54b71ec85a67"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9827,10 +9827,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-d68758"
+       "968cdc841e1ba85b"
       ],
       "only_ungated": [
-       "s-0990d5"
+       "f86a54b71ec85a67"
       ]
      },
      "rank_diff": {
@@ -9838,10 +9838,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0990d5": -3,
-       "s-bf11f7": 1,
-       "s-d68758": 1,
-       "s-d89438": 1
+       "3b7d212b8daa0561": 1,
+       "6b19a539ecb227d8": 1,
+       "968cdc841e1ba85b": 1,
+       "f86a54b71ec85a67": -3
       }
      }
     }
@@ -9855,7 +9855,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-8e3a6c0e74df"
+    "2fb07191f4298060"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9889,11 +9889,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2c2200e04628": 1,
-       "o-837632290379": 1,
-       "o-8e3a6c0e74df": -4,
-       "o-beb29261b342": 1,
-       "o-f71a52246f2e": 1
+       "228b90247f7820f3": 1,
+       "2fb07191f4298060": -4,
+       "bd910064d55b52f7": 1,
+       "cba8ee8c08a5e189": 1,
+       "d45671b52525b12b": 1
       }
      }
     }
@@ -9907,10 +9907,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-136291",
-    "r-1b4bf3",
-    "s-9ad0da",
-    "s-bc1763"
+    "017b799c7b936809",
+    "08606a790c1294ac",
+    "5064d7599d2bb87c",
+    "8fd1febf324e5d1d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9935,10 +9935,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-cd9c7f"
+       "6f5d708f098be05f"
       ],
       "only_ungated": [
-       "s-bc1763"
+       "8fd1febf324e5d1d"
       ]
      },
      "rank_diff": {
@@ -9946,11 +9946,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-18cc49": 1,
-       "s-9ad0da": -1,
-       "s-a80529": 1,
-       "s-bc1763": -2,
-       "s-cd9c7f": 1
+       "08606a790c1294ac": -1,
+       "3786aa0d5d8aa3d3": 1,
+       "6f5d708f098be05f": 1,
+       "8fd1febf324e5d1d": -2,
+       "c75696327f0268f7": 1
       }
      }
     }
@@ -9964,8 +9964,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-83f3b474c3ba",
-    "s-f1577adcea4e"
+    "20f4aa5d5c272e2b",
+    "2af005657ed2b0b1"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -9999,13 +9999,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1bd6959af835": 1,
-       "s-25bde11db045": 1,
-       "s-7389f55f05fa": 2,
-       "s-83f3b474c3ba": -5,
-       "s-89c1623da4bb": 1,
-       "s-a94ee578bd5b": 2,
-       "s-f1577adcea4e": -2
+       "0204a958e03bba3c": 1,
+       "20f4aa5d5c272e2b": -5,
+       "2af005657ed2b0b1": -2,
+       "790f94fdc21ff436": 1,
+       "801c01fb19fe316d": 2,
+       "bc9dc1c384f9754e": 2,
+       "fcf2707eb1c4f458": 1
       }
      }
     }
@@ -10019,8 +10019,8 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-f3f8bd",
-    "s-a99d14"
+    "187ca73d6a94f8b0",
+    "672791d4cc0e9ee5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10052,8 +10052,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-d00b88": 1,
-       "o-f3f8bd": -1
+       "187ca73d6a94f8b0": -1,
+       "4eb4685b6f633751": 1
       }
      }
     },
@@ -10062,10 +10062,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-40cb1e"
+       "0f3ea11ab4fc15e9"
       ],
       "only_ungated": [
-       "s-a99d14"
+       "672791d4cc0e9ee5"
       ]
      },
      "rank_diff": {
@@ -10073,10 +10073,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-40cb1e": 1,
-       "s-475aef": 1,
-       "s-57cc32": 1,
-       "s-a99d14": -3
+       "0f3ea11ab4fc15e9": 1,
+       "34178fc1faa5eb34": 1,
+       "672791d4cc0e9ee5": -3,
+       "7593c48dd76b72b5": 1
       }
      }
     }
@@ -10090,11 +10090,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "o-96aa2f66efdd",
-    "r-3f0577237794",
-    "s-210dc1c98d97",
-    "s-5a413788b88b",
-    "s-c418af2c8b67"
+    "36508f047b15c5f4",
+    "a8517bec1aeda401",
+    "cae61897343f67f6",
+    "e52f6f110a50b33b",
+    "ff6c6c7cb60935bf"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10126,9 +10126,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-6acef1430ee2": 1,
-       "o-96aa2f66efdd": -2,
-       "o-f47fe992b3c8": 1
+       "d5fa2550021ce316": 1,
+       "ef0964c67c71378e": 1,
+       "ff6c6c7cb60935bf": -2
       }
      }
     },
@@ -10137,10 +10137,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-871dc4424a43"
+       "1dd3cd875e1e0482"
       ],
       "only_ungated": [
-       "s-c418af2c8b67"
+       "e52f6f110a50b33b"
       ]
      },
      "rank_diff": {
@@ -10148,20 +10148,20 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0576bf56164c": 2,
-       "s-1430c1643b8d": 3,
-       "s-204f2c8ef725": 3,
-       "s-210dc1c98d97": -8,
-       "s-23fd05de8a8a": 1,
-       "s-5a413788b88b": -7,
-       "s-871dc4424a43": 2,
-       "s-8efd52fec375": 2,
-       "s-98074152d9e1": 3,
-       "s-a20774fdc1ae": 1,
-       "s-c418af2c8b67": -7,
-       "s-cf80ee8476ad": 2,
-       "s-d0fbea21f751": 2,
-       "s-e8a15242fcfb": 1
+       "086317714210bb39": 1,
+       "10bbd8b5f36a22b2": 3,
+       "113ffe60dafe42b9": 2,
+       "190aa2f7f5546bfb": 2,
+       "1dd3cd875e1e0482": 2,
+       "4ad79c73b81a195c": 3,
+       "4b143aebe8180289": 1,
+       "9fd0a2c212c1616f": 2,
+       "a8517bec1aeda401": -8,
+       "cae61897343f67f6": -7,
+       "dd9615ced24352c9": 2,
+       "e52f6f110a50b33b": -7,
+       "ed4533069ca0e87c": 3,
+       "f77126058382b000": 1
       }
      }
     }
@@ -10175,11 +10175,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-793f24a35b16",
-    "s-1100e8c4d9b3",
-    "s-883859dccce6",
-    "s-b96736b77aae",
-    "s-fd35d08257de"
+    "00bf848291bc0442",
+    "0cf75b9a9a3f192c",
+    "3b6c900b2799822c",
+    "f41497a44ec94813",
+    "f452f7394e2bcce0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10204,10 +10204,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-9bf4affb9792"
+       "4199a835348b38eb"
       ],
       "only_ungated": [
-       "s-fd35d08257de"
+       "f41497a44ec94813"
       ]
      },
      "rank_diff": {
@@ -10215,13 +10215,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1100e8c4d9b3": -3,
-       "s-883859dccce6": -3,
-       "s-9393e814a8e6": 4,
-       "s-9bf4affb9792": 4,
-       "s-b96736b77aae": -3,
-       "s-fbd12c8d3cae": 3,
-       "s-fd35d08257de": -2
+       "00bf848291bc0442": -3,
+       "0cf75b9a9a3f192c": -3,
+       "3b6c900b2799822c": -3,
+       "4199a835348b38eb": 4,
+       "54d077d19890dc32": 3,
+       "b9f85041b153ffa9": 4,
+       "f41497a44ec94813": -2
       }
      }
     }
@@ -10235,7 +10235,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-a0915b56d6af"
+    "04f5e635bc81e2eb"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10269,9 +10269,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-600d17dc86d2": 1,
-       "s-695e8da106ee": 1,
-       "s-a0915b56d6af": -2
+       "04f5e635bc81e2eb": -2,
+       "a848e6dac4771aa7": 1,
+       "d638a7dd3a1c6361": 1
       }
      }
     }
@@ -10285,10 +10285,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-3847ef3cc03c",
-    "r-4a0ed1d3654e",
-    "r-f60408f5fd5a",
-    "s-f56d11b0d3bb"
+    "627a88c3bda0c145",
+    "6f2f7792092f374a",
+    "7037b8eca5b61559",
+    "fd23d9e1db2cbef6"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10322,11 +10322,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-50b2343d6fc2": 1,
-       "s-db57c8fde027": 1,
-       "s-ea318bb01c4d": 1,
-       "s-eec61deb6864": 1,
-       "s-f56d11b0d3bb": -4
+       "05a0219f67fcffd0": 1,
+       "2430b0922225be90": 1,
+       "4c31c91aa43313cf": 1,
+       "cb5d30ac666a68f1": 1,
+       "fd23d9e1db2cbef6": -4
       }
      }
     }
@@ -10340,7 +10340,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-fb41ef"
+    "48c62327805f6e0f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10374,8 +10374,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3f207f": 1,
-       "s-fb41ef": -1
+       "48c62327805f6e0f": -1,
+       "ab3e7a62f8880693": 1
       }
      }
     }
@@ -10389,8 +10389,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-678c7def8ecc",
-    "s-f940f0a60794"
+    "0476edf4bfa6d307",
+    "6c1464b2ee572694"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10422,12 +10422,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-003921a30178": 1,
-       "s-54e154e7b785": 2,
-       "s-678c7def8ecc": -2,
-       "s-7c0d51c26aae": 2,
-       "s-f940f0a60794": -4,
-       "s-ffa9fbf35ccd": 1
+       "0476edf4bfa6d307": -2,
+       "6c1464b2ee572694": -4,
+       "b8bd650900bb8535": 2,
+       "c71146a598376ec2": 1,
+       "c99d10638d56ecd2": 1,
+       "ff809d748aeb07f2": 2
       }
      }
     }
@@ -10441,18 +10441,18 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 12,
    "lid_biting_items": [
-    "r-3374a53925b0",
-    "r-58cc6220de9f",
-    "r-61f4eb441957",
-    "r-68d562079b18",
-    "r-696fbe37fcf7",
-    "r-baabcf125472",
-    "r-ce257f475373",
-    "r-e601637d261d",
-    "r-ed741fcd5b3d",
-    "s-05625105a3ef",
-    "s-4492dbd8e229",
-    "s-f951b6302730"
+    "147428e2cd91e600",
+    "3552d0c0977d2024",
+    "63f011c5999c9592",
+    "640fe1b1ff940072",
+    "69f51304a9ae94fc",
+    "792ecc71d853f208",
+    "86403a5ee7e7ba8d",
+    "a9718e371b1292ee",
+    "b6ab05b547cec0c2",
+    "cd65d390c9401d3c",
+    "eaac80e251840115",
+    "f44ddf9d2de22167"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10486,16 +10486,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-03094c4cebca": 3,
-       "s-05625105a3ef": -6,
-       "s-333210aaf013": 2,
-       "s-4492dbd8e229": -6,
-       "s-8b0735ddf5f9": 3,
-       "s-96b9f34e13d6": 3,
-       "s-a15984c682f3": 1,
-       "s-c832fe502882": 2,
-       "s-ec9744347596": 3,
-       "s-f951b6302730": -5
+       "147428e2cd91e600": -6,
+       "2308587a9a52aaac": 3,
+       "2eabcf7e22c10b2e": 1,
+       "3e5d654ea06e83f4": 2,
+       "623cdee840e92d38": 3,
+       "63f011c5999c9592": -5,
+       "640fe1b1ff940072": -6,
+       "8352aa2557b6e80d": 2,
+       "cf92f4c6a086d7e1": 3,
+       "f2aa6f380180445f": 3
       }
      }
     }
@@ -10509,8 +10509,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-0ecf7ade9546",
-    "s-9f743c153b04"
+    "2bb613c61fc7a4b9",
+    "64af36ac2199d823"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10542,10 +10542,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-778acc24790a": 1,
-       "s-94112f9e57dc": 1,
-       "s-9f743c153b04": -3,
-       "s-ffa4a95d03df": 1
+       "2bb613c61fc7a4b9": -3,
+       "91d0b3ee43f70823": 1,
+       "cee64bec48b2e5a8": 1,
+       "e192136ede6c322b": 1
       }
      }
     }
@@ -10559,13 +10559,13 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "h:34ffb994ce4e",
-    "o-9c7c45cc93fd",
-    "r-20a93bfd35d6",
-    "r-74f638a49387",
-    "s-6ffe8173ffcc",
-    "s-7e796f8c22be",
-    "s-c19bed4dd833"
+    "35ee6d2c95226c61",
+    "4b3570a1cbafa2ce",
+    "5d739e8ffd03882b",
+    "68ac77d8a8d2cf19",
+    "7f4448476406cf25",
+    "ac40162444dbbf97",
+    "d5a54f389f88e884"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10599,8 +10599,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-4f15449d866a": 1,
-       "o-9c7c45cc93fd": -1
+       "1999e5a3bc0d3ff6": 1,
+       "7f4448476406cf25": -1
       }
      }
     },
@@ -10616,13 +10616,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5cb404b7ef84": 3,
-       "s-6ffe8173ffcc": -3,
-       "s-73e215c9954c": 2,
-       "s-7e796f8c22be": -4,
-       "s-c19bed4dd833": -2,
-       "s-c1afe3894169": 1,
-       "s-cd4ce8e5ff57": 3
+       "29f3c8bdfec7b950": 1,
+       "35ee6d2c95226c61": -2,
+       "40999fd19590cfa1": 3,
+       "5d739e8ffd03882b": -3,
+       "ac40162444dbbf97": -4,
+       "d3d049484100fc0d": 2,
+       "ee028f8f8a22b718": 3
       }
      }
     }
@@ -10636,13 +10636,13 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-659209edffa2",
-    "r-d2d2cdaab0d2",
-    "r-f713cd794fc6",
-    "s-4fe8183a7a77",
-    "s-8f87cf295e15",
-    "s-c861f8561115",
-    "s-d440e4fc1be8"
+    "013b5d9d37451c46",
+    "3ba270ba2f667484",
+    "6f8a15f763eda896",
+    "7558041e607ecf68",
+    "7a0698fdd37929d9",
+    "9944532eaf9b876c",
+    "d63fdcda2f845b23"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10676,25 +10676,25 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2939e867a816": 1,
-       "s-477f2a1c2e2f": 1,
-       "s-493018b1d43b": 2,
-       "s-4fe8183a7a77": -6,
-       "s-5505be2e63fb": 2,
-       "s-5cf3d755f37a": 3,
-       "s-7dbcddcfa68e": 3,
-       "s-8f87cf295e15": -9,
-       "s-967d162e4ae1": 3,
-       "s-9fffb4fa8dc9": 2,
-       "s-a4c65a43ef0f": 4,
-       "s-abb4e73eb27d": 3,
-       "s-b5cd2b8003f2": 1,
-       "s-c861f8561115": -10,
-       "s-d440e4fc1be8": -9,
-       "s-daa70512551f": 2,
-       "s-e0d421fcbb49": 2,
-       "s-e51c8d008d87": 3,
-       "s-ff75940a71bc": 2
+       "05cd776d54bfecc5": 1,
+       "0b6a56bee80efd38": 2,
+       "170c3fe6ae449391": 1,
+       "198b794e442205ec": 1,
+       "1aa2c5c7b23bff0a": 2,
+       "3ba270ba2f667484": -10,
+       "4993d937319244ab": 4,
+       "501ba051a53a1b29": 2,
+       "5eea636efac58cab": 2,
+       "6bb3f079d6146826": 2,
+       "6f8a15f763eda896": -6,
+       "7558041e607ecf68": -9,
+       "81f559da67345baa": 3,
+       "8ace4b8b05af923b": 3,
+       "95db76c64900ccbf": 3,
+       "9944532eaf9b876c": -9,
+       "bbbb3077f8424793": 3,
+       "e200919ba54c4c90": 2,
+       "f8a2c03eca6697db": 3
       }
      }
     }
@@ -10708,23 +10708,23 @@
    "n_flipped_items": 17,
    "n_lid_biting_flips": 17,
    "lid_biting_items": [
-    "r-106ddd",
-    "r-3e0b7c",
-    "r-3ff437",
-    "r-421157",
-    "r-5dff8f",
-    "r-77ecd7",
-    "r-9d25f7",
-    "r-bd9731",
-    "r-f8e883",
-    "r-fa940f",
-    "s-0412e1",
-    "s-041bab",
-    "s-45c500",
-    "s-5dcc2c",
-    "s-691239",
-    "s-804a1a",
-    "s-842b19"
+    "13927e4d40b91194",
+    "2225ecc1468d0ee1",
+    "28095d8aa58a454d",
+    "4111bed6d8cd2d40",
+    "46b507edbb2cff8f",
+    "4d264d467089c6dc",
+    "7753336e2046d32f",
+    "7d8a127837bdb225",
+    "ba5f6670a6143dba",
+    "bccc698fe146c714",
+    "c30fef6084c1dc94",
+    "c93b6b8619b99a57",
+    "d4441faa10031ec6",
+    "d5402d2e3b6dca31",
+    "d7f0988d78d0a759",
+    "de38a936aabd593b",
+    "df9d562373a71a25"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10758,22 +10758,22 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0412e1": -4,
-       "s-041bab": -6,
-       "s-1f562b": 5,
-       "s-2a3f22": 5,
-       "s-36e033": 1,
-       "s-38ec2f": 7,
-       "s-45c500": -9,
-       "s-4f2c06": 3,
-       "s-5dcc2c": -7,
-       "s-6813bc": 7,
-       "s-691239": -6,
-       "s-7055b0": 7,
-       "s-804a1a": -4,
-       "s-842b19": -7,
-       "s-94ea4a": 1,
-       "s-e1bc2a": 7
+       "041c1485536ab454": 1,
+       "11642ec58100276f": 7,
+       "13927e4d40b91194": -9,
+       "2225ecc1468d0ee1": -4,
+       "28dd248594767300": 3,
+       "39b6f9192600282c": 7,
+       "4111bed6d8cd2d40": -6,
+       "4d264d467089c6dc": -6,
+       "7222e867a96f6733": 5,
+       "87c7dee33d1ce4a3": 7,
+       "b044ba47c5712558": 1,
+       "c30fef6084c1dc94": -7,
+       "cf374ab9fc9f9a1c": 7,
+       "d4441faa10031ec6": -4,
+       "ddaa6f8f3eb26b7f": 5,
+       "de38a936aabd593b": -7
       }
      }
     }
@@ -10787,14 +10787,14 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-55a6a7fa5804",
-    "r-9908a4d8f042",
-    "s-1f154a0e9234",
-    "s-6df014aeaec5",
-    "s-79b195c0335c",
-    "s-be659c2f3456",
-    "s-f4f81774b5ee",
-    "u-5529db531f48"
+    "099356629bbaa079",
+    "09c6ae8742a1968b",
+    "34c59780c7cbcbec",
+    "4a0eb21d84e0a32e",
+    "6b18f610088954b3",
+    "831231cab07f786b",
+    "b9a1604ef5f27cee",
+    "c8ba335c3b5d53d2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10828,20 +10828,20 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1c31b23d30d7": 5,
-       "s-1f154a0e9234": -7,
-       "s-20f2c432d205": 5,
-       "s-34e78dd727fd": 5,
-       "s-4fb9f77066c3": 5,
-       "s-57141d2e0d49": 1,
-       "s-6df014aeaec5": -9,
-       "s-79b195c0335c": -7,
-       "s-79f2a40698ab": 5,
-       "s-7cb3b75ab015": 5,
-       "s-9ae68d5af3a7": 1,
-       "s-be659c2f3456": -7,
-       "s-ce87f508036c": 5,
-       "s-f4f81774b5ee": -7
+       "09c6ae8742a1968b": -9,
+       "0e3e7f80319bb8d4": 5,
+       "1e07dbfc9ed822bb": 5,
+       "2de3d4d3664db309": 5,
+       "3228097fbc759653": 5,
+       "34c59780c7cbcbec": -7,
+       "39a58265517371e8": 1,
+       "492ec2f2f93caf54": 5,
+       "4a0eb21d84e0a32e": -7,
+       "6b18f610088954b3": -7,
+       "831231cab07f786b": -7,
+       "86a2f973bad49d96": 5,
+       "a9daa53c28be5973": 5,
+       "e4e345da71101637": 1
       }
      }
     },
@@ -10857,8 +10857,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-2fa5385f9035": 1,
-       "u-5529db531f48": -1
+       "473b9ddc3fb9def9": 1,
+       "b9a1604ef5f27cee": -1
       }
      }
     }
@@ -10872,13 +10872,13 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-09c21907af19",
-    "r-38b92d2606b4",
-    "s-7c9f02c074eb",
-    "s-c01ed5543f1d",
-    "s-e767e986fb17",
-    "s-f92064d36d78",
-    "s-ffa146d02207"
+    "07460b11473b9596",
+    "0a38de1846ef7b5e",
+    "5d63d9af1312fa50",
+    "708b7e9b6b88af83",
+    "7d87990be1ac4493",
+    "83255d296f1fa940",
+    "8adcb52c845f169d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10910,28 +10910,28 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2f6e8d6d6ca9": 5,
-       "s-34d04bff18b5": 4,
-       "s-4a3e427ba574": 5,
-       "s-4ba477f11dc7": 4,
-       "s-5977c9a9db5e": 5,
-       "s-69702a7b7eab": 5,
-       "s-7c9f02c074eb": -14,
-       "s-882c1bdd124c": 5,
-       "s-8ecf8fc92a08": 1,
-       "s-9975af4e33e2": 1,
-       "s-9dbecff3a129": 5,
-       "s-ade14442f07e": 4,
-       "s-ae6464b10546": 5,
-       "s-c01ed5543f1d": -12,
-       "s-c3f3f9422351": 5,
-       "s-cf7860c6f9b8": 5,
-       "s-d2862b613d85": 5,
-       "s-e767e986fb17": -14,
-       "s-e816441e20ff": 5,
-       "s-e86ac5047019": 1,
-       "s-f92064d36d78": -14,
-       "s-ffa146d02207": -16
+       "051b07853a97f9e0": 1,
+       "0a38de1846ef7b5e": -14,
+       "1d9a648dba2636d6": 5,
+       "22868829a1b02335": 5,
+       "38f86aef8f7b015a": 4,
+       "44792132e7011452": 5,
+       "5a18700c39700be2": 5,
+       "5d63d9af1312fa50": -16,
+       "62356b97f705f761": 5,
+       "635d9d7e2c9a3d35": 5,
+       "695f9eeb95d48fc5": 4,
+       "6c082c1a89f01764": 5,
+       "708b7e9b6b88af83": -12,
+       "745235d79f8a20f2": 5,
+       "7d87990be1ac4493": -14,
+       "83255d296f1fa940": -14,
+       "91ad7f815cf0dac0": 5,
+       "a3ff1aea2d2674fd": 5,
+       "bd9c76469e3fbd51": 1,
+       "e4df77a71255e1a5": 1,
+       "eff7aba1c43b7cd7": 4,
+       "fe685ff754f6f812": 5
       }
      }
     }
@@ -10945,10 +10945,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-2217eb1cabe5",
-    "r-46f37eed72bf",
-    "s-1aea43ef7c60",
-    "s-5d3bcc365f95"
+    "3acd59ba2005e244",
+    "486ca70516efa8ed",
+    "7671c95f89d439f0",
+    "7ec05d194716292a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -10976,8 +10976,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1aea43ef7c60": -1,
-       "s-46f50ec80167": 1
+       "3acd59ba2005e244": -1,
+       "7bd901f7c72db541": 1
       }
      }
     }
@@ -10991,8 +10991,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-04fe20442c70",
-    "s-ae0ba2390fc8"
+    "5b74ac18311429b6",
+    "e84ce204554be642"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11024,8 +11024,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-04fe20442c70": -1,
-       "s-787916be872e": 1
+       "00e7c0d3bba6f026": 1,
+       "e84ce204554be642": -1
       }
      }
     }
@@ -11039,12 +11039,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "h:cab83d5e8456",
-    "r-8f198eb5aac1",
-    "r-a3088eef5b2c",
-    "r-b52710f63d11",
-    "s-24f6e552b6e0",
-    "s-be3935a84d32"
+    "06782baa2ad0c0ff",
+    "0c5f50cb3b51a4c0",
+    "123325b91cd85d68",
+    "22d7c227da5905e5",
+    "250453ac49f0c025",
+    "336d4f2002e46ba8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11078,14 +11078,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-05a8fd7a72fc": 2,
-       "s-248e4f00e50b": 2,
-       "s-24f6e552b6e0": -5,
-       "s-2a06d9c602d0": 2,
-       "s-b0a81979858b": 2,
-       "s-be3935a84d32": -6,
-       "s-e3a6ef55ceb5": 2,
-       "s-f0d144551e54": 1
+       "0c5f50cb3b51a4c0": -5,
+       "20b08c8561362379": 2,
+       "336d4f2002e46ba8": -6,
+       "645dee9aeeca3372": 2,
+       "96c6b7e44614bb88": 2,
+       "be3d40064b3b823c": 1,
+       "c7e91129cc33054b": 2,
+       "f2224fbd49296aaa": 2
       }
      }
     }
@@ -11099,22 +11099,22 @@
    "n_flipped_items": 17,
    "n_lid_biting_flips": 16,
    "lid_biting_items": [
-    "o-080b0f5942af",
-    "o-8096031c3f26",
-    "o-e6c70acbd403",
-    "r-0b8fa37b7fd5",
-    "r-1a919505605e",
-    "r-4ecada3df843",
-    "r-7088496f67ad",
-    "r-b761e391626e",
-    "r-d33225c11375",
-    "r-ffedd10e0dc9",
-    "s-4429c6522419",
-    "s-935fd789dfbe",
-    "s-a3d381fc2fec",
-    "s-b11ad6839c36",
-    "s-b6d1eaeb6f7d",
-    "u-a6386b958e0c"
+    "140c18a2259b4017",
+    "591fd47add1e0790",
+    "6277591354dc123f",
+    "6463f1cf5d63ccb4",
+    "6b74695c01479ef3",
+    "6e90d1eef2b304f9",
+    "6fa90b1b9c520636",
+    "74467b3b5a102e81",
+    "90698590cc22fb83",
+    "acd1c99e96235b54",
+    "afcbd074e4a6c842",
+    "ca93512244909d30",
+    "ce68ea9902eec75a",
+    "d47945b90e1aed58",
+    "e96f695061a1422a",
+    "ebf4e71220d7a6b4"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11146,8 +11146,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-8096031c3f26": -1,
-       "o-a8781a9789d1": 1
+       "6b74695c01479ef3": -1,
+       "c3cb5e3860e937e3": 1
       }
      }
     },
@@ -11156,13 +11156,13 @@
      "cap_crossings": {
       "count": 5,
       "only_gated": [
-       "s-9931657a53da",
-       "s-a918f60529cd",
-       "s-f396b638e6e8"
+       "266d0d672eb9133f",
+       "2bb84efc087411c2",
+       "49514e0fa7c484d3"
       ],
       "only_ungated": [
-       "s-b11ad6839c36",
-       "s-b6d1eaeb6f7d"
+       "6e90d1eef2b304f9",
+       "d47945b90e1aed58"
       ]
      },
      "rank_diff": {
@@ -11170,23 +11170,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0a916645b559": 1,
-       "s-0b98f7a72c1c": 1,
-       "s-1b5bfebf7132": 4,
-       "s-4429c6522419": -11,
-       "s-47ca7bd8427b": 4,
-       "s-49a1d7f4b229": 2,
-       "s-688cabaa3a7a": 1,
-       "s-79e7aa10e443": 4,
-       "s-935fd789dfbe": -8,
-       "s-9931657a53da": 4,
-       "s-a3d381fc2fec": -1,
-       "s-a918f60529cd": 4,
-       "s-b11ad6839c36": -6,
-       "s-b6d1eaeb6f7d": -6,
-       "s-c873fc4616e1": 1,
-       "s-dd9d94b83291": 2,
-       "s-f396b638e6e8": 4
+       "140c18a2259b4017": -11,
+       "266d0d672eb9133f": 4,
+       "2bb84efc087411c2": 4,
+       "35453cb0e5802bbe": 4,
+       "3dd1b7582891fc83": 4,
+       "49514e0fa7c484d3": 4,
+       "6e90d1eef2b304f9": -6,
+       "6fa90b1b9c520636": -1,
+       "72afdfd97d8f1080": 2,
+       "8af968be92fb5199": 4,
+       "9ec92a76172dc552": 1,
+       "a4630c482ea6e33a": 2,
+       "d388c93f1e46ee68": 1,
+       "d47945b90e1aed58": -6,
+       "d52ed969cd296148": 1,
+       "e98a208740964da0": 1,
+       "ebf4e71220d7a6b4": -8
       }
      }
     },
@@ -11202,8 +11202,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-7f06b48f3e08": 1,
-       "u-a6386b958e0c": -1
+       "74467b3b5a102e81": -1,
+       "a2b451d9fc8c4366": 1
       }
      }
     }
@@ -11217,14 +11217,14 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "o-138d96",
-    "s-24d88de82f58",
-    "s-4bd044ed8544",
-    "s-526cc12d9141",
-    "s-571e15bc61c3",
-    "s-6ac375c86e3b",
-    "s-7f47d142adcc",
-    "s-da3d1825074d"
+    "0c5ae26cc5bde0e2",
+    "1f79476933ac1794",
+    "40630c107542017d",
+    "af77157ffb2dc8e2",
+    "b4ce9aed7806ebc5",
+    "d709706c03e5abc9",
+    "e9365d10fd808b3d",
+    "f4064aaebb1ee1f9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11249,15 +11249,15 @@
      "cap_crossings": {
       "count": 7,
       "only_gated": [
-       "s-001cdb652452",
-       "s-272ade03e625",
-       "s-47bb42e5b221",
-       "s-4ca6bae2daa8"
+       "3f17cbdcfd8b2ffb",
+       "69af2ac798d6787a",
+       "707ae32d992a09c0",
+       "d8fb9d8c0c7ec677"
       ],
       "only_ungated": [
-       "s-526cc12d9141",
-       "s-6ac375c86e3b",
-       "s-da3d1825074d"
+       "af77157ffb2dc8e2",
+       "e9365d10fd808b3d",
+       "f4064aaebb1ee1f9"
       ]
      },
      "rank_diff": {
@@ -11265,24 +11265,24 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-001cdb652452": 5,
-       "s-10325891c711": 7,
-       "s-1126a7afe8ac": 1,
-       "s-24d88de82f58": -3,
-       "s-272ade03e625": 5,
-       "s-47bb42e5b221": 4,
-       "s-4bd044ed8544": -5,
-       "s-4ca6bae2daa8": 3,
-       "s-526cc12d9141": -9,
-       "s-54788c3c1f0a": 6,
-       "s-571e15bc61c3": -2,
-       "s-578aaf1eac04": 5,
-       "s-6792676f8e89": 3,
-       "s-6ac375c86e3b": -9,
-       "s-74ac2f372644": 1,
-       "s-7f47d142adcc": -6,
-       "s-a1fcd3f977d1": 3,
-       "s-da3d1825074d": -9
+       "0c5ae26cc5bde0e2": -6,
+       "1f79476933ac1794": -2,
+       "27ba19bc45eccc25": 1,
+       "3396bd9c96771fe1": 1,
+       "3f17cbdcfd8b2ffb": 3,
+       "40630c107542017d": -3,
+       "65bdb5f4b4a015f2": 6,
+       "69af2ac798d6787a": 5,
+       "69ee7cda6a363aa2": 7,
+       "707ae32d992a09c0": 5,
+       "8c8fc5934b85d79f": 3,
+       "8f9514686e53cd9c": 5,
+       "af77157ffb2dc8e2": -9,
+       "b4ce9aed7806ebc5": -5,
+       "d8fb9d8c0c7ec677": 4,
+       "e9365d10fd808b3d": -9,
+       "f3ddac3b2b302c7d": 3,
+       "f4064aaebb1ee1f9": -9
       }
      }
     }
@@ -11296,11 +11296,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-158b02",
-    "r-56a249",
-    "r-63a25f",
-    "s-112a43",
-    "s-2ff2cf"
+    "0bf747e877e521a0",
+    "36490ca280ebc34a",
+    "4d70e2b7ffbfd239",
+    "80e463aacd3ed3d2",
+    "c87c747d49b44518"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11334,12 +11334,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-10896a": 2,
-       "s-112a43": -4,
-       "s-2c04bf": 2,
-       "s-2ff2cf": -4,
-       "s-4ca99a": 2,
-       "s-bbd9ad": 2
+       "6bf4f08a841eb25d": 2,
+       "80e463aacd3ed3d2": -4,
+       "a9e7eebe9350f68d": 2,
+       "c87c747d49b44518": -4,
+       "ecf78b6f33b49210": 2,
+       "ff6f65ca996abf00": 2
       }
      }
     }
@@ -11353,8 +11353,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-d646776404b6",
-    "r-3c20495cc2b0"
+    "1f3b2a03e66fe7cb",
+    "9c666a4bbd8b7d94"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11386,8 +11386,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-bfdb6091e962": 1,
-       "o-d646776404b6": -1
+       "3e2a4535beedbde7": 1,
+       "9c666a4bbd8b7d94": -1
       }
      }
     }
@@ -11401,11 +11401,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "h:a3f808cc7638",
-    "o-117c9fbde39a",
-    "r-1aaeed2e621c",
-    "r-ef5dd162ce74",
-    "s-8e8f324731ee"
+    "3830d2c1d5d97b2e",
+    "af3bd36cb404c09c",
+    "c2805f8b17e7d725",
+    "d9889895d418ff80",
+    "f51add52001c2933"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11437,8 +11437,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-117c9fbde39a": -1,
-       "o-bdb1ece5cdfc": 1
+       "574dfcaa8023cdb1": 1,
+       "af3bd36cb404c09c": -1
       }
      }
     },
@@ -11454,12 +11454,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-4d23a20927ee": 1,
-       "s-6f0fdc81bfc7": 1,
-       "s-8e8f324731ee": -5,
-       "s-a45e7fd179d9": 1,
-       "s-a562a7caaddf": 1,
-       "s-a641a7cffec5": 1
+       "6da9c1800914fa7e": 1,
+       "7ef70907bf58d5a6": 1,
+       "a1fd3a29017195e8": 1,
+       "b454746b6dfa99f3": 1,
+       "ce8efa565321e857": 1,
+       "f51add52001c2933": -5
       }
      }
     }
@@ -11473,9 +11473,9 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-df18b9e3ca69",
-    "s-17d1884bbde6",
-    "s-9695c3b497c3"
+    "8e2bffce1f21eb45",
+    "9f1f3e1395fa610f",
+    "c166be525506f8f5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11507,14 +11507,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-17d1884bbde6": -4,
-       "s-3ff5402a819d": 1,
-       "s-77e4b19ef35c": 1,
-       "s-966cafec2687": 1,
-       "s-9695c3b497c3": -3,
-       "s-bf1a40d41495": 1,
-       "s-c996c1031860": 1,
-       "s-dd274e643f0b": 2
+       "44743ea1aaec69d7": 2,
+       "8338b06661a7642f": 1,
+       "8beb090fe3874107": 1,
+       "9f1f3e1395fa610f": -3,
+       "c166be525506f8f5": -4,
+       "d9b396bd8b98052b": 1,
+       "e3eea45e6220738a": 1,
+       "e814e9e597803477": 1
       }
      }
     }
@@ -11528,10 +11528,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "h:88ec9ba7d4f8",
-    "r-079cd2f13594",
-    "s-33c9eca870b0",
-    "s-44bea15d48e3"
+    "27ba41129839f014",
+    "7e1161199e9f8b2a",
+    "9bcfbc842c86dfe7",
+    "da359ebf73688ab4"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11565,11 +11565,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0426d41a4189": 1,
-       "s-17c8da86bb23": 1,
-       "s-33c9eca870b0": -2,
-       "s-44bea15d48e3": -1,
-       "s-844f06aef8bb": 1
+       "3dab0dd5a7f26746": 1,
+       "7e1161199e9f8b2a": -2,
+       "9bcfbc842c86dfe7": -1,
+       "aeaf9803ce72639d": 1,
+       "e38ffe1fd65e02d5": 1
       }
      }
     }
@@ -11583,10 +11583,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-f3e2cd",
-    "r-0fdae4",
-    "r-76198e",
-    "r-9dad17"
+    "634948013bbcb95f",
+    "74d273e462525af9",
+    "86c016d8997b955f",
+    "d295f9ac4e7e34db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11620,10 +11620,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-00ac31": 1,
-       "o-36b14a": 1,
-       "o-c9331e": 1,
-       "o-f3e2cd": -3
+       "41c4e4018b6a3207": 1,
+       "8550d36f9a0d1584": 1,
+       "d295f9ac4e7e34db": -3,
+       "ef6d381e6e355c44": 1
       }
      }
     }
@@ -11637,10 +11637,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-3ef9363379ea",
-    "r-452204a91681",
-    "s-a999f8081db4",
-    "s-bff6469db071"
+    "41a0a0cbf804d104",
+    "52f54c96e5f1e170",
+    "87cecb0c6fe18892",
+    "8baf86387561eb2d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11674,16 +11674,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-09b75d6fad37": 2,
-       "s-3147cbc234ca": 2,
-       "s-35a6862dbd00": 2,
-       "s-3ae4b18e8945": 2,
-       "s-6a9d685962f1": 2,
-       "s-a0dae6703c34": 2,
-       "s-a999f8081db4": -8,
-       "s-b92dbdc5b34f": 2,
-       "s-bff6469db071": -8,
-       "s-c41a11a16d90": 2
+       "18070822fdf6bfa5": 2,
+       "355f762b4860ac0e": 2,
+       "47807268c74ae5d2": 2,
+       "68b24ce81a7bc293": 2,
+       "87cecb0c6fe18892": -8,
+       "8baf86387561eb2d": -8,
+       "ac1a6ce0783dcef3": 2,
+       "ae1026d7e26d6e6a": 2,
+       "c526774ff4e49e2d": 2,
+       "e96425e31b2e4f4b": 2
       }
      }
     }
@@ -11697,11 +11697,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-3e6c76d9cd78",
-    "r-ae60115866c1",
-    "r-c24b56d3f2eb",
-    "s-642a050020f9",
-    "u-266b74a2b77e"
+    "1a987e17fe877605",
+    "4a6b08f63b3d9153",
+    "55480c7b6fb12e29",
+    "c1a8d06970814add",
+    "f3bc1993bc11ac95"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11735,14 +11735,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0aab3c6f6c8d": 1,
-       "s-33e30a0e0b6c": 1,
-       "s-5799ed7ab88e": 1,
-       "s-642a050020f9": -7,
-       "s-8d07f0cf6ed0": 1,
-       "s-8e0e13169257": 1,
-       "s-991c50c888fc": 1,
-       "s-ddf1fc9d09f9": 1
+       "06071588306da4b6": 1,
+       "4a6b08f63b3d9153": -7,
+       "781eee9335f19509": 1,
+       "9989ba0b3ee70527": 1,
+       "b829ab93ee1bd0c6": 1,
+       "bccb1e5f5ce8eff9": 1,
+       "cf5bd2cd6a33f29f": 1,
+       "f721eb20da4786a9": 1
       }
      }
     },
@@ -11758,11 +11758,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-266b74a2b77e": -4,
-       "u-44dca5781ab9": 1,
-       "u-540f58a359cd": 1,
-       "u-67075ac0e8b1": 1,
-       "u-a372ac93b2a3": 1
+       "1a987e17fe877605": -4,
+       "29a7f43aa3ea64e6": 1,
+       "320a6648b8db4e20": 1,
+       "49d8166c52245cde": 1,
+       "e5453d59b0d57145": 1
       }
      }
     }
@@ -11776,12 +11776,12 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-2a2660",
-    "s-d9909e"
+    "45d9a223d599725e",
+    "571971bf25a29403"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-2a2660"
+    "45d9a223d599725e"
    ],
    "over_budget": {
     "gated": true,
@@ -11804,7 +11804,7 @@
      "cap_crossings": {
       "count": 1,
       "only_gated": [
-       "s-9d8059"
+       "ee839a14392bd9cb"
       ],
       "only_ungated": []
      },
@@ -11813,11 +11813,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2a2660": -1,
-       "s-376139": 1,
-       "s-9d8059": 1,
-       "s-cfeb08": 1,
-       "s-d9909e": -2
+       "45d9a223d599725e": -1,
+       "519658a9de3af12b": 1,
+       "571971bf25a29403": -2,
+       "98bb6026693dd116": 1,
+       "ee839a14392bd9cb": 1
       }
      }
     }
@@ -11831,9 +11831,9 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-7d64069c5ad7",
-    "r-bebf28f6caec",
-    "s-09a3d965fe54"
+    "477673fbfdbe92df",
+    "5d94c23b33c6035e",
+    "83b31879e179c5a7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11867,11 +11867,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-09a3d965fe54": -4,
-       "s-1bff2088b4da": 1,
-       "s-1df84ca52893": 1,
-       "s-7fc2f250c8fc": 1,
-       "s-ef5e47e54c2e": 1
+       "33ca5bcf5b1777ac": 1,
+       "388b095f3972fe16": 1,
+       "39a49207869f3bec": 1,
+       "65bddaafdc1e2a10": 1,
+       "83b31879e179c5a7": -4
       }
      }
     }
@@ -11885,12 +11885,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-0dd476",
-    "r-1ca55e",
-    "r-5c9702",
-    "r-5f105e",
-    "s-3bdd4d",
-    "s-d2ea56"
+    "071558f7bb5c5500",
+    "1db062bf0bb3a425",
+    "cb2df9885c2f5b68",
+    "fc63f51786819f6b",
+    "fed77a0db8308d49",
+    "ff95880433328e89"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11915,11 +11915,11 @@
      "cap_crossings": {
       "count": 3,
       "only_gated": [
-       "s-75293a",
-       "s-e19254"
+       "293975c51cfc4d15",
+       "c46ecaf0d37a324b"
       ],
       "only_ungated": [
-       "s-3bdd4d"
+       "fed77a0db8308d49"
       ]
      },
      "rank_diff": {
@@ -11927,13 +11927,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3bdd4d": -5,
-       "s-6bfef5": 1,
-       "s-75293a": 1,
-       "s-ab4076": 2,
-       "s-b90ead": 1,
-       "s-d2ea56": -2,
-       "s-e19254": 2
+       "0506c26ea4e52db0": 1,
+       "293975c51cfc4d15": 1,
+       "8ab36b1778311c8e": 1,
+       "9e9ed483d8ceefb9": 2,
+       "c46ecaf0d37a324b": 2,
+       "cb2df9885c2f5b68": -2,
+       "fed77a0db8308d49": -5
       }
      }
     }
@@ -11947,11 +11947,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-40550787ea83",
-    "r-dc432d8571df",
-    "s-160eb44baf00",
-    "s-793c3ff5a582",
-    "s-ffb650794e86"
+    "0c803c6858759ed1",
+    "7db5546bdbf90c9f",
+    "a43c1e125d95d772",
+    "af5bc5a11a49eabd",
+    "c2af0e2f3ec2d734"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -11983,16 +11983,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-160eb44baf00": -4,
-       "s-294ab0a5dcae": 3,
-       "s-411956b34f63": 3,
-       "s-43a670bf567b": 2,
-       "s-48ec7ba9ec72": 3,
-       "s-5d685c666af4": 3,
-       "s-793c3ff5a582": -7,
-       "s-d2b6f1f902e9": 2,
-       "s-f3986b037efe": 2,
-       "s-ffb650794e86": -7
+       "0c803c6858759ed1": -7,
+       "0dcf8b2743c85b96": 2,
+       "808962b761db6be8": 3,
+       "a43c1e125d95d772": -4,
+       "af5bc5a11a49eabd": -7,
+       "c67dc85642e9329a": 3,
+       "d1e91a4d95fbd1f3": 2,
+       "d8a4935d831d8643": 2,
+       "e8afbbb99653f130": 3,
+       "f4b8cf269f213dd7": 3
       }
      }
     }
@@ -12006,8 +12006,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-1e82dcb2d02f",
-    "s-8233cba79754"
+    "654c8141c0f55030",
+    "f2915a0eb3465126"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12041,15 +12041,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1e82dcb2d02f": -7,
-       "s-2f23a2e9cc0f": 2,
-       "s-6c0e3e1163ea": 1,
-       "s-7d7c201c4010": 1,
-       "s-8233cba79754": -3,
-       "s-8e54cae0c836": 2,
-       "s-9e8c7314013d": 2,
-       "s-a2331c837db7": 1,
-       "s-ac0e0289feaa": 1
+       "041d2e40c32a2399": 2,
+       "2bde950515df9c9a": 2,
+       "449e57661d33b8a8": 1,
+       "4a868a84a2d2893a": 1,
+       "654c8141c0f55030": -7,
+       "8b9c6cbc04a39624": 2,
+       "92da3088a462c8a6": 1,
+       "b6edd06500076531": 1,
+       "f2915a0eb3465126": -3
       }
      }
     }
@@ -12063,21 +12063,21 @@
    "n_flipped_items": 18,
    "n_lid_biting_flips": 15,
    "lid_biting_items": [
-    "h:02b8e176ef83",
-    "r-10d8d821d542",
-    "r-4108a5e6e4a9",
-    "r-425438801945",
-    "r-5fb51e382ec9",
-    "r-6de3b8174627",
-    "r-72a4e55fe201",
-    "r-7a3f832eba6f",
-    "r-97408824f6cc",
-    "r-b049f83519d8",
-    "s-3d68a47c52d4",
-    "s-7cc6a1fac645",
-    "s-bca3bafe81ec",
-    "s-c0104581ab17",
-    "s-e50839496e8c"
+    "098ea3080af2aa54",
+    "354833845f038553",
+    "48f7930fdfd14155",
+    "495052f1b2a28b7f",
+    "732b4afac184617b",
+    "7bdf40d830a845dc",
+    "82e613f89066ac5d",
+    "86d7afbd3e71a815",
+    "8caee4d45b7dbab4",
+    "91b471e2b743dd65",
+    "9356225cf834e69a",
+    "9ff226988486bd71",
+    "b7f0ff2840f90ebb",
+    "c6c921693e7e4392",
+    "e75e447de02a6dd3"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12102,12 +12102,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-8896cd2db93e",
-       "s-914700638a17"
+       "6207ae19ec92ea85",
+       "f50dcd7ab1d1a621"
       ],
       "only_ungated": [
-       "s-7cc6a1fac645",
-       "s-c0104581ab17"
+       "098ea3080af2aa54",
+       "495052f1b2a28b7f"
       ]
      },
      "rank_diff": {
@@ -12115,36 +12115,36 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-04f76ca4ba99": 2,
-       "s-05626971c0a1": 2,
-       "s-09d8c4e7cb57": 4,
-       "s-0c397b235761": 1,
-       "s-1a6737df831b": 4,
-       "s-2af933ceb3f7": 3,
-       "s-34f9493761cc": 3,
-       "s-3d68a47c52d4": -8,
-       "s-40966405e9ae": 2,
-       "s-40c18c89fc55": 3,
-       "s-56cde32a8419": 1,
-       "s-576d2208dc1c": 1,
-       "s-63ac82ab42c0": 2,
-       "s-67db5cfe460c": 1,
-       "s-6ab4e1a9cffe": 1,
-       "s-6add76ad3fb4": 2,
-       "s-6d7acd77b54b": 2,
-       "s-7cc6a1fac645": -13,
-       "s-7ffa798d2925": 2,
-       "s-8896cd2db93e": 2,
-       "s-914700638a17": 2,
-       "s-937f374dd480": 2,
-       "s-9a25c2dd36ad": 4,
-       "s-9b1449c9a076": 1,
-       "s-a861cf2ba2c7": 1,
-       "s-bca3bafe81ec": -6,
-       "s-c0104581ab17": -12,
-       "s-c73712643db1": 1,
-       "s-d0af07117799": 2,
-       "s-e50839496e8c": -12
+       "098ea3080af2aa54": -12,
+       "0fa2cc0051345924": 2,
+       "18a3ba9db942142b": 2,
+       "19604fbbcc5c1625": 1,
+       "1a4ee09254c2e8e9": 1,
+       "20e6fda98c1e8764": 1,
+       "214e15963bc0eba6": 2,
+       "2511eb190dbdcc53": 1,
+       "495052f1b2a28b7f": -13,
+       "4cecb103bdda44c8": 4,
+       "6207ae19ec92ea85": 2,
+       "69e8c3acbb7fb136": 1,
+       "6e5c476d5f581030": 1,
+       "728cae566dc6022f": 2,
+       "732b4afac184617b": -12,
+       "82677ef3011c6cda": 2,
+       "828ee7bd539c060b": 3,
+       "8653a65a3357d0aa": 2,
+       "95b3046e63b939a3": 1,
+       "9917459740883364": 3,
+       "9e9fa964b899c63d": 4,
+       "9ff226988486bd71": -6,
+       "b14a07881fe10bd6": 4,
+       "b7f0ff2840f90ebb": -8,
+       "c932a0a439642a1c": 3,
+       "cf6592d6ceb3073b": 2,
+       "ed90d897f267d46c": 2,
+       "efa49f09b2e74023": 1,
+       "f50dcd7ab1d1a621": 2,
+       "fb6688f2206c4d8f": 2
       }
      }
     }
@@ -12158,22 +12158,22 @@
    "n_flipped_items": 19,
    "n_lid_biting_flips": 16,
    "lid_biting_items": [
-    "o-debe5e141c0b",
-    "r-072f483bb64a",
-    "r-0e3cd4ef4627",
-    "r-0e7362e4a737",
-    "r-2d412fd35364",
-    "r-32dd7abf62ae",
-    "r-606a75cef0c7",
-    "r-a024708cfb79",
-    "r-a8bce3f04ef4",
-    "r-b38a3fdd127b",
-    "r-bb81b219e204",
-    "r-c01ebf57c9af",
-    "r-d91d5d23806d",
-    "r-d93527d29467",
-    "s-64aed3360ee0",
-    "s-b16817e29047"
+    "08742fd6d816ae7e",
+    "39661109cb6b248a",
+    "46ebceb10b574234",
+    "4e3b4fb7f1ba6ac3",
+    "513cafd83c10b71f",
+    "58fbf0b8df1f8e88",
+    "5c74b81e381d9483",
+    "68fea5354c58d3b1",
+    "741110ec38006b57",
+    "843451c0e8f3a5f7",
+    "89de54e16aa811d7",
+    "ba1da7111c7297df",
+    "e28dbcb9d846c809",
+    "f0eb19dd10c3ef86",
+    "f3845cd2cd4cff25",
+    "fa1c64b7c96f1de8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12209,8 +12209,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-075ba7dc0226": 1,
-       "o-debe5e141c0b": -1
+       "741110ec38006b57": -1,
+       "b2a57c45e1c67d24": 1
       }
      }
     },
@@ -12226,26 +12226,26 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1037e37b910e": 2,
-       "s-1da2f0d12d60": 1,
-       "s-2e412982e0e8": 2,
-       "s-31ffe832f41f": 2,
-       "s-3d0df5299527": 2,
-       "s-4a4a756063d7": 2,
-       "s-4e89bbdc29a0": 1,
-       "s-57bb428efb57": 2,
-       "s-64aed3360ee0": -15,
-       "s-66e719508316": 1,
-       "s-76fd9fbccbd6": 1,
-       "s-7c0a2bb295f2": 1,
-       "s-81f2de8bb451": 1,
-       "s-89e918a7ba5e": 1,
-       "s-a7a261609a86": 1,
-       "s-b16817e29047": -10,
-       "s-cab615cdb452": 1,
-       "s-e410e4a971f5": 1,
-       "s-e59b6d34aa3a": 1,
-       "s-eed4b498d666": 2
+       "021e52e594b8c1b4": 1,
+       "18f6d97dff38c6d4": 2,
+       "202cf3c2f890db3e": 1,
+       "2818a9e0bca0a8d3": 1,
+       "3d1ef8fb35f5d43e": 1,
+       "3edefb3853c3c610": 1,
+       "44bd80e292f7b56f": 2,
+       "533f60a1a3a552bd": 1,
+       "68fea5354c58d3b1": -10,
+       "8715d40afbec81f0": 1,
+       "a0bc8c7ddf24bbbf": 2,
+       "b152d75a34478108": 1,
+       "b29b79e8d113a6f4": 2,
+       "d8bdf6bf308e4e77": 1,
+       "def236dc352210af": 2,
+       "ef574bba579f77ff": 2,
+       "f0eb19dd10c3ef86": -15,
+       "f0ffa6db1e9756a8": 1,
+       "f35756faf5583542": 1,
+       "f80558842fd6644a": 2
       }
      }
     }
@@ -12259,7 +12259,7 @@
    "n_flipped_items": 19,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-debe5e141c0b"
+    "741110ec38006b57"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12295,8 +12295,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-075ba7dc0226": 1,
-       "o-debe5e141c0b": -1
+       "741110ec38006b57": -1,
+       "b2a57c45e1c67d24": 1
       }
      }
     }
@@ -12310,14 +12310,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-44423b0ab9b8",
-    "r-715a3175a186",
-    "r-a2133cc8f28f",
-    "r-a618ede96a4c",
-    "r-c356cd16a59f",
-    "r-f6227e270364",
-    "s-9e61a4e83657",
-    "s-b3383f736d09"
+    "00a8792f45cbb360",
+    "289f325c0b8f0e62",
+    "618550e34127c3da",
+    "765753f37cff72e5",
+    "7d8a3c1b337fc383",
+    "c4fb175e9088134c",
+    "dc2f8525f71c3513",
+    "fe7044b62e00d238"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12351,17 +12351,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-01ef198440d2": 1,
-       "s-1471ff7e63ad": 2,
-       "s-1f5e9b71bc04": 1,
-       "s-2a80f4b1fa67": 1,
-       "s-32f097c75aa4": 2,
-       "s-633ec7d2cc37": 1,
-       "s-66d3f2ca51e0": 1,
-       "s-67221259a6fc": 1,
-       "s-9e61a4e83657": -8,
-       "s-b3383f736d09": -3,
-       "s-c79869b971c5": 1
+       "005b4f4dab77236f": 1,
+       "1eefd3736a5eecbe": 2,
+       "25faa164cb6b075e": 2,
+       "4e3b94d9b684760e": 1,
+       "765753f37cff72e5": -8,
+       "789e737af075c1ab": 1,
+       "8890462324972937": 1,
+       "b76eefc085e7ca30": 1,
+       "beca191a410620d9": 1,
+       "fe7044b62e00d238": -3,
+       "fecc0443c1d373b3": 1
       }
      }
     }
@@ -12375,13 +12375,13 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "o-24b9ad",
-    "r-5bcea7",
-    "r-61ccfc",
-    "r-63a25f",
-    "s-875cde",
-    "s-c96fc6",
-    "s-ea4ff9"
+    "4d70e2b7ffbfd239",
+    "87beb84f31c4b014",
+    "973d09b3b3011047",
+    "acff624ed5b3e92f",
+    "c4d39fb17b5eda07",
+    "cfa7b80d8d1a6061",
+    "ffec8b5d5f98c6ae"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12415,13 +12415,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5aa07c": 3,
-       "s-7e7d78": 2,
-       "s-875cde": -4,
-       "s-8937b6": 3,
-       "s-9222f2": 1,
-       "s-c96fc6": -2,
-       "s-ea4ff9": -3
+       "46182324be29b8b1": 1,
+       "90da9e9d6bd95a34": 3,
+       "973d09b3b3011047": -4,
+       "98757cde6d98e355": 2,
+       "acff624ed5b3e92f": -3,
+       "c4d39fb17b5eda07": -2,
+       "e59458d09db272b0": 3
       }
      }
     }
@@ -12435,9 +12435,9 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-01e245",
-    "r-ac3e1e",
-    "s-d7aff5"
+    "35821bb2add2d6cd",
+    "c742a44891b31289",
+    "ca91d7db85b3c63b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12471,15 +12471,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-190607": 1,
-       "s-30e0bc": 1,
-       "s-556ddd": 1,
-       "s-6c3449": 1,
-       "s-8876d2": 1,
-       "s-99c2b8": 1,
-       "s-ce9364": 1,
-       "s-d7aff5": -8,
-       "s-f3a2b4": 1
+       "04dd089be215041b": 1,
+       "0ea505bee5889c52": 1,
+       "25becc386f43e0c2": 1,
+       "35821bb2add2d6cd": -8,
+       "4ecab0195d7b377d": 1,
+       "98ef3f2f74ccb753": 1,
+       "b56ee0802b569699": 1,
+       "b73366261fa58eed": 1,
+       "e159e50e9ce3e0e1": 1
       }
      }
     }
@@ -12493,10 +12493,10 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-1d0ea7",
-    "r-fe631b",
-    "s-4ec848",
-    "s-f79b23"
+    "21fb0e2d76e01f86",
+    "5f9a9f6819db6dfc",
+    "61461136b0a8700d",
+    "98d09e566bfa7276"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12521,10 +12521,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-1e1ce4"
+       "fb8b284a48031eab"
       ],
       "only_ungated": [
-       "s-f79b23"
+       "61461136b0a8700d"
       ]
      },
      "rank_diff": {
@@ -12532,14 +12532,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-17084b": 1,
-       "s-1e1ce4": 1,
-       "s-4ec848": -1,
-       "s-5b25b0": 1,
-       "s-6af724": 1,
-       "s-914bfc": 1,
-       "s-dc3551": 1,
-       "s-f79b23": -5
+       "5f9a9f6819db6dfc": -1,
+       "61461136b0a8700d": -5,
+       "8f54e9378a952dd4": 1,
+       "be5a2a9c769772be": 1,
+       "d75a92717ba3c80c": 1,
+       "e02ed7d89f9c683a": 1,
+       "f5a5d63dc7c21027": 1,
+       "fb8b284a48031eab": 1
       }
      }
     }
@@ -12553,16 +12553,16 @@
    "n_flipped_items": 13,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "r-36e6756c1a73",
-    "r-713869f95a7d",
-    "r-9dddc64be06e",
-    "r-d16607634836",
-    "r-edd87b9b8c80",
-    "r-f47157f172f3",
-    "r-f67bf89339dd",
-    "s-971991d385b3",
-    "s-982eb58ae089",
-    "s-ea4b901bd333"
+    "050e132914a0f1ce",
+    "0886462bb0d4fac5",
+    "26d62b6da77e09b1",
+    "58ce838d557d3992",
+    "65b2cb64d56bc381",
+    "920db0538be86c8f",
+    "bdcee00d9ce87eb0",
+    "cbeb6132a98dc3db",
+    "d719fff224e139d8",
+    "ec6a608490388642"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12587,11 +12587,11 @@
      "cap_crossings": {
       "count": 3,
       "only_gated": [
-       "s-583abd66e538",
-       "s-d94018b7174e"
+       "a01465f98e72cda3",
+       "bf2966a0c1ce5bb9"
       ],
       "only_ungated": [
-       "s-982eb58ae089"
+       "cbeb6132a98dc3db"
       ]
      },
      "rank_diff": {
@@ -12599,16 +12599,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-15d3c01012fb": 2,
-       "s-583abd66e538": 3,
-       "s-8a0a1e976954": 2,
-       "s-971991d385b3": -3,
-       "s-982eb58ae089": -5,
-       "s-d71e2d8faec9": 1,
-       "s-d94018b7174e": 3,
-       "s-ea4b901bd333": -6,
-       "s-f1d1921f3bfd": 2,
-       "s-f604bd294da9": 1
+       "038b96c4e11c5763": 2,
+       "050e132914a0f1ce": -3,
+       "0e9161720037f69d": 1,
+       "36f29b56608f1ef3": 1,
+       "a01465f98e72cda3": 3,
+       "a05d8d3bb4958e79": 2,
+       "bf2966a0c1ce5bb9": 3,
+       "c9fcd76185c0c768": 2,
+       "cbeb6132a98dc3db": -5,
+       "ec6a608490388642": -6
       }
      }
     }
@@ -12622,11 +12622,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-68ba23f32f51",
-    "s-21e1538bdb20",
-    "s-49c1ebadb82e",
-    "s-8e9daaf7db70",
-    "s-97d7015ff8c0"
+    "2a119e345888ddff",
+    "53af8739c4e1956c",
+    "d33836b368f827de",
+    "e115fdc78bf25ae7",
+    "f5c8f68d4087f1c7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12660,32 +12660,32 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-02cdabb18f45": 3,
-       "s-044d85b80f49": 4,
-       "s-209567ebbabc": 4,
-       "s-2133b94f171f": 4,
-       "s-21e1538bdb20": -13,
-       "s-49c1ebadb82e": -22,
-       "s-67e9a32f6f25": 4,
-       "s-756328e32f05": 4,
-       "s-7a65495efb76": 3,
-       "s-82e5c7083c89": 4,
-       "s-875358f28d97": 2,
-       "s-87e7f6baa099": 4,
-       "s-8e9daaf7db70": -18,
-       "s-967269d1ebfc": 3,
-       "s-97d7015ff8c0": -22,
-       "s-a83c0f03e9ec": 4,
-       "s-d662ef2b020b": 3,
-       "s-d9158ef4aec2": 4,
-       "s-dead0c6de006": 4,
-       "s-dfb0c92d863e": 2,
-       "s-e076329d6c62": 4,
-       "s-e2b0f89c15c8": 3,
-       "s-e76ea20d6d2a": 2,
-       "s-e96b9c4b7e02": 4,
-       "s-ec2db2e4795e": 2,
-       "s-f4922cc3e418": 4
+       "0bb2de2bb3c22d11": 4,
+       "1441535520945fcc": 4,
+       "1c9ce62088a24900": 3,
+       "2a119e345888ddff": -22,
+       "3e40729f55e7be9b": 4,
+       "4588f7ddf1cd3d7d": 4,
+       "47b837fc4393ce2f": 4,
+       "53af8739c4e1956c": -18,
+       "5eb61d8c7b0863f3": 3,
+       "6013ff5c69699519": 4,
+       "67f6125d58c614c6": 3,
+       "786b06b5aa6046ba": 2,
+       "7a8baddd2f38fe63": 2,
+       "87f444d4fc0becc5": 4,
+       "b238e7c34fd1a7ea": 2,
+       "b7fd7db76d2ee179": 4,
+       "bd92ffd3fe089b4a": 2,
+       "bed2f85b056f1917": 3,
+       "c3709f935ff31ee1": 4,
+       "c46632d79ff0b094": 4,
+       "ce6c33bc853360d4": 3,
+       "d33836b368f827de": -22,
+       "e0657c4acd41de1a": 4,
+       "e115fdc78bf25ae7": -13,
+       "faea3f8aca0822be": 4,
+       "fb3be74a0f41ea91": 4
       }
      }
     }
@@ -12699,11 +12699,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-5f1e61",
-    "r-83bb25",
-    "r-e73d32",
-    "s-1a04a5",
-    "s-64ce88"
+    "2b8c3fd39b8579d9",
+    "62d7fd833447282c",
+    "8539f3ac5d0a508e",
+    "b5f3c55be89c6903",
+    "bb0c4f0563740305"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12737,11 +12737,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1a04a5": -1,
-       "s-35138f": 1,
-       "s-64ce88": -3,
-       "s-84e426": 2,
-       "s-f35160": 1
+       "2b8c3fd39b8579d9": -3,
+       "75041b3641d401bb": 2,
+       "8539f3ac5d0a508e": -1,
+       "87cf3c956d0701b8": 1,
+       "d6c7d6b28b238153": 1
       }
      }
     }
@@ -12755,10 +12755,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-3253a18a2154",
-    "r-aec21dbf131c",
-    "s-32dd7b72385e",
-    "s-bf358665add2"
+    "505c6fcb01a77b88",
+    "5f37319ce7db8212",
+    "71ef62581c020e22",
+    "eaecb6fb26904fa2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12783,12 +12783,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-8dbedbaaca57",
-       "s-b234b013d733"
+       "3207bf68c3843ea1",
+       "bad07e70e341cd98"
       ],
       "only_ungated": [
-       "s-32dd7b72385e",
-       "s-bf358665add2"
+       "505c6fcb01a77b88",
+       "eaecb6fb26904fa2"
       ]
      },
      "rank_diff": {
@@ -12796,15 +12796,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-32dd7b72385e": -7,
-       "s-352a468d0fa1": 2,
-       "s-54eacaeab14f": 1,
-       "s-5af25ca91a9b": 2,
-       "s-635a8a71a8e6": 1,
-       "s-76371b591f6e": 2,
-       "s-8dbedbaaca57": 2,
-       "s-b234b013d733": 2,
-       "s-bf358665add2": -5
+       "140c05a55941638a": 2,
+       "3207bf68c3843ea1": 2,
+       "505c6fcb01a77b88": -5,
+       "97d77f53854fe58e": 1,
+       "9976f0fa9ee3fd28": 1,
+       "b523cd28bb94e972": 2,
+       "bad07e70e341cd98": 2,
+       "c21fd09202b93380": 2,
+       "eaecb6fb26904fa2": -7
       }
      }
     }
@@ -12818,16 +12818,16 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "o-795b9fa3c201",
-    "o-902974e60f6d",
-    "r-7660e5cc4f29",
-    "r-b4f8fe02495c",
-    "r-f43dac8f856c",
-    "r-f74001c238d0",
-    "s-07e5dfd011d1",
-    "s-21691e24a399",
-    "s-464cdff25355",
-    "s-5d5cbfd21165"
+    "09fa27d1496e3e44",
+    "58f6101da60d4586",
+    "6444f463c00f500e",
+    "845776fa65e92e8b",
+    "89faad657b367c7d",
+    "8a733387b655170e",
+    "8e09cda707a4c922",
+    "c402c95596c66c36",
+    "d21c68461bb8d267",
+    "f9027ed1f0fe6cb0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12861,12 +12861,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-663c288d0ed9": 1,
-       "o-795b9fa3c201": -3,
-       "o-85f43c200743": 2,
-       "o-902974e60f6d": -4,
-       "o-bfdb6091e962": 2,
-       "o-e506e8a1862f": 2
+       "1af0c9193a0aac61": 2,
+       "3e2a4535beedbde7": 2,
+       "42281627e506a085": 2,
+       "845776fa65e92e8b": -4,
+       "89faad657b367c7d": -3,
+       "e785968a32d4f732": 1
       }
      }
     },
@@ -12882,17 +12882,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-07e5dfd011d1": -6,
-       "s-21691e24a399": -6,
-       "s-3bbc4a0a32cd": 4,
-       "s-464cdff25355": -4,
-       "s-5d5cbfd21165": -6,
-       "s-671533dd714e": 4,
-       "s-6c0b21768828": 1,
-       "s-96935478845e": 3,
-       "s-c60d96325b99": 4,
-       "s-ccfaff8d842c": 3,
-       "s-f0ca39c3a7ed": 3
+       "1054f8dc04f0ea2b": 4,
+       "27c35796548b41bc": 3,
+       "2f985490fbb66e26": 1,
+       "58f6101da60d4586": -6,
+       "5c154a03429f5a3b": 3,
+       "9286d63f3cc7eb8a": 4,
+       "a293f26c10d56bde": 3,
+       "a6d12993ded587e9": 4,
+       "c402c95596c66c36": -6,
+       "d21c68461bb8d267": -6,
+       "f9027ed1f0fe6cb0": -4
       }
      }
     }
@@ -12906,7 +12906,7 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-902974e60f6d"
+    "845776fa65e92e8b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -12940,8 +12940,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-663c288d0ed9": 1,
-       "o-902974e60f6d": -1
+       "845776fa65e92e8b": -1,
+       "e785968a32d4f732": 1
       }
      }
     }
@@ -12955,18 +12955,18 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-120729",
-    "r-54d71a",
-    "r-59698e",
-    "r-782e80",
-    "r-c7527c",
-    "r-e573de",
-    "s-06e6d1",
-    "s-7e5281"
+    "1e31677ed7a01a27",
+    "6bd0e1452021c4a9",
+    "6c72f1374b4edfdf",
+    "b4c6c85b6318d01d",
+    "c65e46b3109f6315",
+    "ce429f8b22b27b70",
+    "d42d56dbf237a8ab",
+    "ea881e708bbaeaba"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-c7527c"
+    "d42d56dbf237a8ab"
    ],
    "over_budget": {
     "gated": true,
@@ -12989,11 +12989,11 @@
      "cap_crossings": {
       "count": 3,
       "only_gated": [
-       "s-00e999",
-       "s-debb05"
+       "a661831b049ba869",
+       "e240797f4be67e5d"
       ],
       "only_ungated": [
-       "s-7e5281"
+       "ce429f8b22b27b70"
       ]
      },
      "rank_diff": {
@@ -13001,10 +13001,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-00e999": 2,
-       "s-06e6d1": -2,
-       "s-7e5281": -2,
-       "s-debb05": 2
+       "a661831b049ba869": 2,
+       "b4c6c85b6318d01d": -2,
+       "ce429f8b22b27b70": -2,
+       "e240797f4be67e5d": 2
       }
      }
     }
@@ -13018,12 +13018,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-0091a7472260",
-    "r-1ef02e7d8820",
-    "r-81b835737116",
-    "r-9adc3b808cfa",
-    "r-d988bc242f4e",
-    "s-7629fc740147"
+    "27afa720663a74a5",
+    "46dcee090480215a",
+    "4a696640c31135a2",
+    "5464cf7436a7a312",
+    "54901279227c752c",
+    "59152fad07ccfa8c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13055,11 +13055,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1e7dffd917d9": 1,
-       "s-451e9d75381a": 1,
-       "s-7629fc740147": -4,
-       "s-87128abd5cbc": 1,
-       "s-a79418bbc6b3": 1
+       "06d375359253831d": 1,
+       "4a696640c31135a2": -4,
+       "54e59f6a9cc81e18": 1,
+       "c8c91a68846affc6": 1,
+       "ef9d18e1a6ceaea7": 1
       }
      }
     }
@@ -13073,7 +13073,7 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-d0246fc247f9"
+    "6a38700504f5047a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13107,9 +13107,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-d0246fc247f9": -2,
-       "s-d98d6f640ded": 1,
-       "s-f86a74f5f1b3": 1
+       "6a38700504f5047a": -2,
+       "84435ccad7dab4e6": 1,
+       "f8b39e3c9e9120bb": 1
       }
      }
     }
@@ -13123,35 +13123,35 @@
    "n_flipped_items": 28,
    "n_lid_biting_flips": 25,
    "lid_biting_items": [
-    "o-83beda4c7e72",
-    "o-ba61ffa8aa5c",
-    "r-0049f457be9f",
-    "r-06898a0235b6",
-    "r-194f6342d161",
-    "r-1f52b722a25a",
-    "r-3a82b1722d34",
-    "r-5126d3cabdfa",
-    "r-612477569400",
-    "r-8ac11aaaea9e",
-    "r-8add38270397",
-    "r-a8b1c4567966",
-    "r-ad98fb4473f4",
-    "r-b5b34bb8fdd9",
-    "r-c2bc16bd5831",
-    "r-ccc267c16468",
-    "r-cef5381111f3",
-    "r-d4a5a1e021c9",
-    "r-e2059b300fe1",
-    "r-ec800e60a387",
-    "r-f5a956f647a4",
-    "s-034c23db060b",
-    "s-17beddf54a6d",
-    "s-47fd3cafe4f9",
-    "s-ca02253e8b1a"
+    "16c1ccc8dc3fbc6f",
+    "20393bbb9bde7790",
+    "20ee9bc4d85ad106",
+    "26bd5551404f7f0a",
+    "29dfaf28c7c01664",
+    "39ce4ffd7456f2e4",
+    "3cb57cf603ac2358",
+    "45dea0f6782fa5f0",
+    "576186ede03aafcb",
+    "63609b4d24a97b83",
+    "7034e0c0f03096a4",
+    "7083708eae5e4584",
+    "821ed069e7b070c9",
+    "82a0a6e8f5162404",
+    "993519cf350ce48a",
+    "9bd9f63feaba4651",
+    "9d8f14f662f29cdb",
+    "9fd7fdea0eecac38",
+    "a8cb3d3b7b905bd8",
+    "bab563d1a4532239",
+    "be38564901432e0b",
+    "c62670e4107f6aad",
+    "df91f39c9d3b5afc",
+    "f317076496add956",
+    "fb3fc4e1d5f202af"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-ca02253e8b1a"
+    "bab563d1a4532239"
    ],
    "over_budget": {
     "gated": true,
@@ -13183,9 +13183,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-83beda4c7e72": -1,
-       "o-ba61ffa8aa5c": -1,
-       "o-d7cf084041bb": 2
+       "20ee9bc4d85ad106": -1,
+       "993519cf350ce48a": -1,
+       "e9b54b61c203b2e6": 2
       }
      }
     },
@@ -13201,23 +13201,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-034c23db060b": -10,
-       "s-16843eec78f5": 4,
-       "s-17beddf54a6d": -9,
-       "s-451e48ef828f": 1,
-       "s-47fd3cafe4f9": -9,
-       "s-4d0bc7d6bb34": 1,
-       "s-5a310c77f163": 2,
-       "s-5c995d09b8c5": 4,
-       "s-5e9c62506ade": 2,
-       "s-81950091cfd1": 4,
-       "s-890d17fc9e3b": 4,
-       "s-9774a54e092f": 3,
-       "s-a8e8aa179739": 4,
-       "s-b969479ba06f": 1,
-       "s-ca02253e8b1a": -9,
-       "s-ca35fb504164": 4,
-       "s-f40d4855e804": 3
+       "0a2e325f8c8608da": 3,
+       "16c1ccc8dc3fbc6f": -9,
+       "1f71609c752e47cf": 1,
+       "212e49cf80137862": 4,
+       "75515dcc6361e3fe": 1,
+       "7551d88bd3110edd": 1,
+       "79329162d4ab4fd2": 3,
+       "90da9136caf60ee8": 2,
+       "a299bd92418e28f8": 2,
+       "a6124565a252ee18": 4,
+       "bab563d1a4532239": -9,
+       "bc3900299542e4f3": 4,
+       "be38564901432e0b": -9,
+       "be620722e79a5ab4": 4,
+       "ce7566fd90537fbf": 4,
+       "f0838af16c2a94b4": 4,
+       "f317076496add956": -10
       }
      }
     }
@@ -13231,12 +13231,12 @@
    "n_flipped_items": 28,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-83beda4c7e72",
-    "o-ba61ffa8aa5c"
+    "20ee9bc4d85ad106",
+    "993519cf350ce48a"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-ca02253e8b1a"
+    "bab563d1a4532239"
    ],
    "over_budget": {
     "gated": true,
@@ -13268,9 +13268,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-83beda4c7e72": -1,
-       "o-ba61ffa8aa5c": -1,
-       "o-d7cf084041bb": 2
+       "20ee9bc4d85ad106": -1,
+       "993519cf350ce48a": -1,
+       "e9b54b61c203b2e6": 2
       }
      }
     }
@@ -13284,7 +13284,7 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-62aa976fae62"
+    "9e027831b17ca75a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13316,9 +13316,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-01838612a5fe": 1,
-       "s-2eecc902d12e": 1,
-       "s-62aa976fae62": -2
+       "6083b7363a611d51": 1,
+       "82f628192a33c11b": 1,
+       "9e027831b17ca75a": -2
       }
      }
     }
@@ -13332,31 +13332,31 @@
    "n_flipped_items": 25,
    "n_lid_biting_flips": 25,
    "lid_biting_items": [
-    "o-4d24b4",
-    "o-768300",
-    "r-17e845",
-    "r-271a32",
-    "r-2cf3c8",
-    "r-376a82",
-    "r-582a3f",
-    "r-63650f",
-    "r-694c83",
-    "r-6efedb",
-    "r-822dcd",
-    "r-9363f6",
-    "r-afff29",
-    "r-ce2752",
-    "r-d4c3d5",
-    "r-d7dbf0",
-    "s-3c3b98",
-    "s-3dc743",
-    "s-50b400",
-    "s-92a6b4",
-    "s-ae9b47",
-    "s-bca5b2",
-    "s-c76fc7",
-    "u-22e44e",
-    "u-7301f8"
+    "0101538798869b75",
+    "039dedb9a64a80b0",
+    "05f05979585b66ed",
+    "06d62c00a607b83c",
+    "0cb066e1930d6c37",
+    "39049654ab1fefeb",
+    "70edb51ac0944c32",
+    "7581b4d8947de730",
+    "768f2632f2fb8d49",
+    "7ab4f7e16d886600",
+    "810acd8b3398b7eb",
+    "884cc67238a9c978",
+    "974f9bce1d905ecb",
+    "975bf3da14f9d75a",
+    "9b98d077592c9689",
+    "ab8639ff17ec6865",
+    "c2eba35320491d39",
+    "cba4e245734db5c8",
+    "e2fca4a5b06ccfbb",
+    "e6b750a7e85bb570",
+    "e6ee7b09a51d6055",
+    "e73963887564631b",
+    "e8758477ade3c261",
+    "f1616cfbade412fe",
+    "f36b12a093c9a801"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13390,17 +13390,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-1a8dba": 1,
-       "o-326f43": 2,
-       "o-46560b": 1,
-       "o-4d24b4": -6,
-       "o-768300": -7,
-       "o-7a5dad": 2,
-       "o-80e544": 1,
-       "o-ce0b06": 1,
-       "o-dfd23e": 1,
-       "o-eff95f": 2,
-       "o-f0f244": 2
+       "06d62c00a607b83c": -7,
+       "196419a716d0fa92": 2,
+       "472d1e7889934f9f": 2,
+       "56f1b9881437945e": 2,
+       "61af6215f6091076": 2,
+       "72a8074535d36672": 1,
+       "7581b4d8947de730": -6,
+       "75e76b6ea7023c4a": 1,
+       "82d4589eab5043cb": 1,
+       "aa979f9a1412318e": 1,
+       "f6f9581a7e4ac64a": 1
       }
      }
     },
@@ -13416,22 +13416,22 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-17741d": 2,
-       "s-3c3b98": -3,
-       "s-3dc743": -9,
-       "s-50b400": -4,
-       "s-6ebaa7": 4,
-       "s-84ba0b": 5,
-       "s-8620dc": 1,
-       "s-922595": 2,
-       "s-9a78b2": 2,
-       "s-a5c49a": 5,
-       "s-ab38bb": 6,
-       "s-ae9b47": -10,
-       "s-bca5b2": -4,
-       "s-c42c6c": 2,
-       "s-c76fc7": -1,
-       "s-d29e01": 2
+       "169fef0b55e68274": 1,
+       "3828c42523135adb": 2,
+       "768f2632f2fb8d49": -3,
+       "810acd8b3398b7eb": -10,
+       "a0388eece3cf811b": 2,
+       "c2eba35320491d39": -9,
+       "c4ceeea38bb0ddd9": 4,
+       "cba4e245734db5c8": -1,
+       "cddac8bbbb6c717f": 2,
+       "d32d9887f3aed67d": 5,
+       "dc5becffda7bb3b0": 2,
+       "e1f05b0b67123e88": 5,
+       "e2fca4a5b06ccfbb": -4,
+       "e73963887564631b": -4,
+       "f816ebed63681330": 6,
+       "f9265a695e67b7c8": 2
       }
      }
     },
@@ -13447,11 +13447,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-22e44e": -1,
-       "u-24047d": 1,
-       "u-558f3a": 2,
-       "u-7301f8": -3,
-       "u-f66894": 1
+       "3b3181437d93fa3d": 1,
+       "4ca5df3d18c03701": 2,
+       "6eef689cf878ed32": 1,
+       "884cc67238a9c978": -1,
+       "e6b750a7e85bb570": -3
       }
      }
     }
@@ -13465,8 +13465,8 @@
    "n_flipped_items": 25,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-4d24b4",
-    "o-768300"
+    "06d62c00a607b83c",
+    "7581b4d8947de730"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13500,15 +13500,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-1a8dba": 1,
-       "o-4d24b4": -2,
-       "o-768300": -5,
-       "o-7a5dad": 1,
-       "o-80e544": 1,
-       "o-ce0b06": 1,
-       "o-dfd23e": 1,
-       "o-eff95f": 1,
-       "o-f0f244": 1
+       "06d62c00a607b83c": -5,
+       "472d1e7889934f9f": 1,
+       "56f1b9881437945e": 1,
+       "61af6215f6091076": 1,
+       "72a8074535d36672": 1,
+       "7581b4d8947de730": -2,
+       "75e76b6ea7023c4a": 1,
+       "aa979f9a1412318e": 1,
+       "f6f9581a7e4ac64a": 1
       }
      }
     }
@@ -13522,24 +13522,24 @@
    "n_flipped_items": 17,
    "n_lid_biting_flips": 13,
    "lid_biting_items": [
-    "o-dd3e23",
-    "r-4234f2",
-    "r-46c96d",
-    "r-6057c8",
-    "r-8cb08d",
-    "s-199adb",
-    "s-453dac",
-    "s-67e0e2",
-    "s-7b91d5",
-    "s-83c5fa",
-    "s-d3b43b",
-    "s-eb0889",
-    "s-ee2b12"
+    "17b1a534d5c31036",
+    "2816baed8d45dfe2",
+    "7711a017742cfa47",
+    "774261b6c88a92c4",
+    "8819b2dfd226150e",
+    "a7a0abefbfe891bf",
+    "a81fd7db8a0e2855",
+    "b94c91618eb855d8",
+    "c15736721778175b",
+    "c20cb7c2e53b3c3f",
+    "cf3118a161fab32f",
+    "d5e3acaa1bb6ffc4",
+    "df1b3f7794555adb"
    ],
    "n_truncation_exempting_flips": 2,
    "truncation_exempting_items": [
-    "s-83c5fa",
-    "s-d3b43b"
+    "17b1a534d5c31036",
+    "cf3118a161fab32f"
    ],
    "over_budget": {
     "gated": true,
@@ -13571,14 +13571,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-43774e": 1,
-       "o-49088f": 1,
-       "o-4b6c03": 1,
-       "o-4d4e1c": 1,
-       "o-d602c7": 1,
-       "o-dca808": 1,
-       "o-dd3e23": -7,
-       "o-eabca6": 1
+       "1322b4b838024219": 1,
+       "2ef1a714955d4691": 1,
+       "373f5db58fa9bbac": 1,
+       "638a9825d464554e": 1,
+       "715109726c296e4e": 1,
+       "774261b6c88a92c4": -7,
+       "b385e54fc10182e2": 1,
+       "bba72e689037f774": 1
       }
      }
     },
@@ -13594,19 +13594,19 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-199adb": -4,
-       "s-29ec71": 2,
-       "s-453dac": -1,
-       "s-67e0e2": -3,
-       "s-7b91d5": -4,
-       "s-83c5fa": -4,
-       "s-a5d98e": 6,
-       "s-c5d25d": 5,
-       "s-d3b43b": -4,
-       "s-e69910": 4,
-       "s-eadc14": 6,
-       "s-eb0889": -2,
-       "s-ee2b12": -1
+       "17b1a534d5c31036": -4,
+       "2816baed8d45dfe2": -4,
+       "45ff75c42b1eca08": 5,
+       "6e043c4e2c00457c": 6,
+       "76b79a33301723d3": 6,
+       "831bc586a96b505e": 4,
+       "8819b2dfd226150e": -1,
+       "a7a0abefbfe891bf": -2,
+       "a81fd7db8a0e2855": -1,
+       "b71b312f6b756540": 2,
+       "c15736721778175b": -4,
+       "cf3118a161fab32f": -4,
+       "d5e3acaa1bb6ffc4": -3
       }
      }
     }
@@ -13620,12 +13620,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-276c4595a45b",
-    "r-452fdd892fbe",
-    "r-83dcbba776e8",
-    "r-841e87c140a6",
-    "r-d121ea19ae39",
-    "s-e1ea039fd9f7"
+    "1179e1344efd9bcf",
+    "4b3d13e7bbf1b51c",
+    "6651a544aeaa81aa",
+    "c6c3b6e92b3ab960",
+    "dd6b1e1fc16ac876",
+    "f81bd2ad2d0f78d8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13657,11 +13657,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-18766c116d18": 1,
-       "s-3d5529194026": 1,
-       "s-9ddd7b71324e": 1,
-       "s-da2f6b53f2b8": 1,
-       "s-e1ea039fd9f7": -4
+       "6cf09a1e9f8f70b3": 1,
+       "7bb9859649e89dcb": 1,
+       "91505a4bf7b74f2c": 1,
+       "c6c3b6e92b3ab960": -4,
+       "e0d3a673eb4c2ee2": 1
       }
      }
     }
@@ -13675,7 +13675,7 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-23af7c2adea8"
+    "02c4f80898847e79"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13703,11 +13703,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-13987a06cb07": 1,
-       "s-23af7c2adea8": -4,
-       "s-463ec64a322f": 1,
-       "s-a699669e1a99": 1,
-       "s-aa28fe7fd459": 1
+       "02c4f80898847e79": -4,
+       "273224cbf48eb898": 1,
+       "7058ee4dec7944c4": 1,
+       "c419348e80d6bebe": 1,
+       "cd35ac4e067d26a1": 1
       }
      }
     }
@@ -13721,16 +13721,16 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "r-05f2af2c3824",
-    "r-147d98ac9d6f",
-    "r-1899432a93d1",
-    "r-21ac6e63f8cf",
-    "r-c7a4b88e8f16",
-    "r-fbcdcfdea531",
-    "s-0ac9011074e5",
-    "s-0cbe3f64bfaf",
-    "s-a60cf09c6422",
-    "s-f065e8f2e7b5"
+    "2921d02206d8e6d5",
+    "3e51875c5cb19183",
+    "57c19a384d2886a9",
+    "6d9fc56276841da3",
+    "adff2812c354d58a",
+    "b18d23e63b443fa6",
+    "bcc319f8d54f87b1",
+    "ce577918fd546410",
+    "d2b5cde1fd52feda",
+    "fdef2e2e007fbd3e"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13766,21 +13766,21 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-01592cda58fe": 2,
-       "s-0ac9011074e5": -4,
-       "s-0cbe3f64bfaf": -7,
-       "s-68090a7cffcc": 2,
-       "s-720c9b6564f0": 1,
-       "s-7e0a3d4b4d67": 2,
-       "s-876c04e0ad19": 1,
-       "s-9ebfa615bd5a": 3,
-       "s-a60cf09c6422": -3,
-       "s-b5006cb48ee6": 1,
-       "s-bc5ed9cfbbf6": 2,
-       "s-c35748c97410": 2,
-       "s-d59e007e5d56": 1,
-       "s-eb07220a7164": 1,
-       "s-f065e8f2e7b5": -4
+       "14ce261b8e2e27c8": 2,
+       "36694e17448ff646": 3,
+       "3e51875c5cb19183": -4,
+       "3f0de0992f5dbb0a": 2,
+       "454bcd2962fa13e1": 1,
+       "7e6266db36899666": 1,
+       "875c846fa6ac1e5a": 2,
+       "96350d8605bdbe33": 1,
+       "ae77201f03c027c7": 1,
+       "bcc319f8d54f87b1": -3,
+       "c138df521dc9e075": 2,
+       "ce03c3b746bdbcd9": 1,
+       "ce577918fd546410": -4,
+       "d2b5cde1fd52feda": -7,
+       "ebc9936f90a2a637": 2
       }
      }
     }
@@ -13794,14 +13794,14 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-058ded33c833",
-    "r-2d7cc0f382c9",
-    "r-685a170c6fd5",
-    "r-cde8b4415900",
-    "r-d539a0d76223",
-    "s-546bf907ceda",
-    "s-c91bbce15518",
-    "s-d16b053bc866"
+    "0ddec02701c0a14c",
+    "1533ff3f1fc3a696",
+    "1d7973a7f42e11ad",
+    "3b6cfacce566bd22",
+    "5d0067ce14f3e0a4",
+    "a4d2214d4c94f2e7",
+    "f227d1c9a0a201c9",
+    "f8d24dde7a319df2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13833,14 +13833,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-078262337eb8": 3,
-       "s-2fbf07c3e21c": 3,
-       "s-506152489b2a": 3,
-       "s-546bf907ceda": -4,
-       "s-c4213595657b": 1,
-       "s-c91bbce15518": -5,
-       "s-d16b053bc866": -4,
-       "s-e4984a5e14a1": 3
+       "0ddec02701c0a14c": -4,
+       "1533ff3f1fc3a696": -5,
+       "1ae2a681b5cd5c44": 3,
+       "2f4b3c8f48321601": 3,
+       "7292898fb93f7110": 3,
+       "73771a1c7fcfbbcd": 3,
+       "a5764dd8064d38c4": 1,
+       "f227d1c9a0a201c9": -4
       }
      }
     }
@@ -13854,8 +13854,8 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-60aab3755fe3",
-    "s-345088f42d6c"
+    "3d4fcfa0c50f266f",
+    "d1d9cc57620d26da"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13887,11 +13887,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2079b2556cc0": 1,
-       "s-345088f42d6c": -4,
-       "s-53824073b148": 1,
-       "s-7e923da92102": 1,
-       "s-b8618173fcbe": 1
+       "088570ca64bda8cd": 1,
+       "1672bf5441897fe4": 1,
+       "3d4fcfa0c50f266f": -4,
+       "5a6d82fb0e7b1624": 1,
+       "fd2052c2d7631b51": 1
       }
      }
     }
@@ -13905,8 +13905,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-ad5991c7c565",
-    "s-1794685f8714"
+    "059827629653b504",
+    "ca5dcc4a15db8b82"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13940,12 +13940,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1794685f8714": -5,
-       "s-85af95d36859": 1,
-       "s-861952d98dd3": 1,
-       "s-8d955adb3f80": 1,
-       "s-aed8a2b77fa7": 1,
-       "s-c9622f7b9bef": 1
+       "32b9ef2c04904d18": 1,
+       "552bfe191a000c34": 1,
+       "b18fef0cb659ed41": 1,
+       "ca5dcc4a15db8b82": -5,
+       "e1dffd4a27fa9166": 1,
+       "fa506d0caa959ae0": 1
       }
      }
     }
@@ -13959,10 +13959,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-2194d0120086",
-    "r-2681b0a26be1",
-    "r-f5bfff1ef08d",
-    "s-6ea52280a91a"
+    "18758b0692df2144",
+    "23c23fe38ce3f6a6",
+    "70764b6d3dcfb9e9",
+    "92804635b6427927"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -13996,9 +13996,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-2194d0120086": -2,
-       "o-761fedd08eca": 1,
-       "o-a92e0e64c9aa": 1
+       "5b3957f0b13b2a77": 1,
+       "5b71f7c847d11183": 1,
+       "92804635b6427927": -2
       }
      }
     },
@@ -14014,11 +14014,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-00dfa4224242": 1,
-       "s-04de31ed6437": 1,
-       "s-6ea52280a91a": -4,
-       "s-724c089eef9b": 1,
-       "s-adc6adef5335": 1
+       "08b7599cc18bc855": 1,
+       "0df4e65596c109fc": 1,
+       "70764b6d3dcfb9e9": -4,
+       "dd385266014cbf2e": 1,
+       "de31352c79b081fc": 1
       }
      }
     }
@@ -14032,8 +14032,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-ad40e25ef49f",
-    "s-8406d4b767ca"
+    "66960d2217f7e590",
+    "dd409cde9097e98b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14058,10 +14058,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-e4ebb8fafa5d"
+       "28238af1729cbdeb"
       ],
       "only_ungated": [
-       "s-8406d4b767ca"
+       "66960d2217f7e590"
       ]
      },
      "rank_diff": {
@@ -14069,12 +14069,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0d89ceba5f8a": 1,
-       "s-35b222df2dd4": 1,
-       "s-68f421697091": 1,
-       "s-8406d4b767ca": -5,
-       "s-e36275a65c75": 1,
-       "s-e4ebb8fafa5d": 1
+       "1d6c8a740a261844": 1,
+       "28238af1729cbdeb": 1,
+       "66960d2217f7e590": -5,
+       "a6bdb2cd399e71ce": 1,
+       "d7a5183bbddd3796": 1,
+       "df006c9da987810e": 1
       }
      }
     }
@@ -14088,8 +14088,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-691764ddd72c",
-    "s-f52419c599b1"
+    "1f423e4a27fb71bf",
+    "cb10a2a1bc102915"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14121,11 +14121,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0fa50a112a7c": 1,
-       "s-628d1089a75a": 1,
-       "s-76e79f34ce14": 1,
-       "s-9ed3d693c69e": 1,
-       "s-f52419c599b1": -4
+       "73c3caa287d02b49": 1,
+       "7bca8c25d0c7a34e": 1,
+       "a62dc11cf80628c9": 1,
+       "c6f37fbbc6b9407e": 1,
+       "cb10a2a1bc102915": -4
       }
      }
     }
@@ -14139,15 +14139,15 @@
    "n_flipped_items": 16,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "o-530373dcdc8c",
-    "r-1e2d5464b335",
-    "r-284c4dff80c3",
-    "r-3727da0e8ab9",
-    "r-5769b5bf377c",
-    "r-a79620bbb62d",
-    "s-6b48f506bc8d",
-    "s-82b69c3c7b60",
-    "s-d9830ab1c248"
+    "07f7b2fb9cff5426",
+    "1559d909c6f3067a",
+    "194e49ebe675ea44",
+    "236b85b5369c2664",
+    "73d681339cb38f34",
+    "88a8d43b84f3afd6",
+    "b3e000c3ee8769dd",
+    "ea88dd9cd147f725",
+    "f235fb388f5df2f7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14181,9 +14181,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-11a9b816e931": 1,
-       "o-530373dcdc8c": -2,
-       "o-973322c3226f": 1
+       "64e049195a6649bb": 1,
+       "9dd95ed9d1dcfd22": 1,
+       "b3e000c3ee8769dd": -2
       }
      }
     },
@@ -14199,17 +14199,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-31ea32e9060b": 3,
-       "s-4f8e61500a55": 3,
-       "s-6b48f506bc8d": -7,
-       "s-82b69c3c7b60": -8,
-       "s-8d5832ca052c": 1,
-       "s-a4edbe08e9b2": 3,
-       "s-ba783d6464ed": 3,
-       "s-bf79549021f0": 3,
-       "s-c1b6b2a7ad05": 3,
-       "s-ce6c6e42768a": 3,
-       "s-d9830ab1c248": -7
+       "04b23a7064bddfdc": 3,
+       "07cb5410dd7eeb9b": 3,
+       "07f7b2fb9cff5426": -8,
+       "1559d909c6f3067a": -7,
+       "235bc0d1cd7ec6c6": 3,
+       "2de4799e2a8dbf04": 3,
+       "5c8926063e6463a4": 1,
+       "7368d7b1b7034f64": 3,
+       "c2ad3911f2c1c9d1": 3,
+       "e678e871d28d6e42": 3,
+       "f235fb388f5df2f7": -7
       }
      }
     }
@@ -14223,15 +14223,15 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-120729",
-    "r-5f6ff1",
-    "r-782e80",
-    "s-85df72",
-    "u-58ea51"
+    "3d1cdda1a70129d3",
+    "811e8e62a581758d",
+    "c65e46b3109f6315",
+    "ea881e708bbaeaba",
+    "fa18796bc28927d0"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-120729"
+    "ea881e708bbaeaba"
    ],
    "over_budget": {
     "gated": true,
@@ -14263,12 +14263,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-24311a": 1,
-       "s-7a2072": 1,
-       "s-85df72": -5,
-       "s-a04722": 1,
-       "s-c3d374": 1,
-       "s-e860ec": 1
+       "4cc3759b3e514272": 1,
+       "56166608149ab0e2": 1,
+       "90206d3aad44fa4c": 1,
+       "bd466217fc94660c": 1,
+       "c24433cc5e85d250": 1,
+       "fa18796bc28927d0": -5
       }
      }
     },
@@ -14277,7 +14277,7 @@
      "cap_crossings": {
       "count": 1,
       "only_gated": [
-       "u-fd0e74"
+       "f79a4a63427789cd"
       ],
       "only_ungated": []
      },
@@ -14286,13 +14286,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-00e00c": 1,
-       "u-253f49": 1,
-       "u-4a151b": 1,
-       "u-58ea51": -6,
-       "u-5ca1f0": 1,
-       "u-8c249c": 1,
-       "u-fd0e74": 1
+       "3d1cdda1a70129d3": -6,
+       "68efadd2139e9bc7": 1,
+       "81c6154f91fbe81c": 1,
+       "c9ea7ccdd4f2b720": 1,
+       "d689cc76803eb477": 1,
+       "d8427c537566912e": 1,
+       "f79a4a63427789cd": 1
       }
      }
     }
@@ -14308,7 +14308,7 @@
    "lid_biting_items": [],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-120729"
+    "ea881e708bbaeaba"
    ],
    "over_budget": {
     "gated": true,
@@ -14333,7 +14333,7 @@
      "cap_crossings": {
       "count": 1,
       "only_gated": [
-       "u-8fad4a"
+       "b7917cdc1e8894e2"
       ],
       "only_ungated": []
      },
@@ -14354,17 +14354,17 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 11,
    "lid_biting_items": [
-    "h:81668a8db177",
-    "r-08246a",
-    "r-509e73",
-    "r-63cebf",
-    "r-7ca647",
-    "r-88e233",
-    "r-9ef30e",
-    "r-a4f3ee",
-    "r-ec6987",
-    "s-77451e",
-    "s-e7f89c"
+    "089c6faa8fe5626b",
+    "129af1457a4785e0",
+    "27b0a1508de64f04",
+    "2d2bf9a63b681ff3",
+    "81bc94cf6bb95b2f",
+    "822b85f3f8aca899",
+    "8e76c745cd3534d4",
+    "a39c2e34c63acf27",
+    "aa20e11d43f4060a",
+    "c2d414be437a64e3",
+    "cd3307c57a053aa4"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14389,7 +14389,7 @@
      "cap_crossings": {
       "count": 1,
       "only_gated": [
-       "s-375b4e"
+       "dd7bf31492a68dad"
       ],
       "only_ungated": []
      },
@@ -14398,13 +14398,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-307a5e": 1,
-       "s-375b4e": 1,
-       "s-5b7623": 1,
-       "s-61e53f": 1,
-       "s-77451e": -2,
-       "s-7eafce": 1,
-       "s-e7f89c": -3
+       "089c6faa8fe5626b": -3,
+       "13f564cc1dea83d7": 1,
+       "52ac7f4f36e9f1c5": 1,
+       "7c8213d96ccb42cd": 1,
+       "a39c2e34c63acf27": -2,
+       "bf0fbff31e2bc0fd": 1,
+       "dd7bf31492a68dad": 1
       }
      }
     }
@@ -14418,10 +14418,10 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-2fe905d594cd",
-    "r-c254c0abf12f",
-    "s-469438a9340c",
-    "s-e5c1b6f9e36c"
+    "25a25fc223d65752",
+    "3aa3bee31db4211c",
+    "3fdfde02c9526752",
+    "ce28d770a0b5805b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14455,14 +14455,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0acb6c478fe5": 1,
-       "s-469438a9340c": -5,
-       "s-4909979a0791": 1,
-       "s-7395f90c3226": 1,
-       "s-7667f0e630bc": 1,
-       "s-7dcee8875fd7": 1,
-       "s-c98d11b1b6df": 1,
-       "s-e5c1b6f9e36c": -1
+       "05c5cb6852ff5422": 1,
+       "25a25fc223d65752": -5,
+       "275e0d0e3b9c2173": 1,
+       "2f9e5798d25d6978": 1,
+       "3fdfde02c9526752": -1,
+       "51d3fdc515ff8088": 1,
+       "5d47ecc1c11fb4a5": 1,
+       "7efd981c58c35d89": 1
       }
      }
     }
@@ -14476,14 +14476,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-ebe9fd712ea7",
-    "r-f5697d477fe2",
-    "r-fa58452e5111",
-    "s-57701061433e",
-    "s-588d71ce8ac8",
-    "s-6fbd67e479c4",
-    "s-7e6988884e1e",
-    "s-9e6a1a292bc6"
+    "1cb1084f822d187e",
+    "23905e76bac56b87",
+    "37744512eeb9ca8f",
+    "61a206c7a195e00e",
+    "67b5dc855c8871fe",
+    "72c51f8a742a65f7",
+    "d33d4880471fc8dc",
+    "ef552e9f8be46ef5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14517,16 +14517,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0e5367c64b04": 2,
-       "s-3c2dff2293db": 5,
-       "s-57701061433e": -5,
-       "s-588d71ce8ac8": -3,
-       "s-6fbd67e479c4": -3,
-       "s-7e6988884e1e": -5,
-       "s-872957e93fa5": 5,
-       "s-9e6a1a292bc6": -3,
-       "s-d90051066e59": 2,
-       "s-e63489cafd8f": 5
+       "01d66a74db8164a9": 5,
+       "1cb1084f822d187e": -5,
+       "5f4757127bb0eda4": 2,
+       "67b5dc855c8871fe": -3,
+       "72c51f8a742a65f7": -5,
+       "b317ba5135d883a8": 2,
+       "d33d4880471fc8dc": -3,
+       "d63a5fd4706bb5fa": 5,
+       "eea491882b87ef9d": 5,
+       "ef552e9f8be46ef5": -3
       }
      }
     }
@@ -14540,7 +14540,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-0d9228"
+    "af25df223a8860e5"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14574,8 +14574,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0d9228": -1,
-       "s-b3e39f": 1
+       "af25df223a8860e5": -1,
+       "c2e00becdc5ec789": 1
       }
      }
     }
@@ -14589,17 +14589,17 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-53060de808e9",
-    "r-eae78150c4cc",
-    "s-137693d1b0ea",
-    "s-1c9dc0e50707",
-    "s-226f94fa3135",
-    "s-c7eb78c43d61",
-    "u-067c2777094f"
+    "20c638c7cad6b9c3",
+    "775fc7e8b660f7a1",
+    "9e334b2556dd3bf0",
+    "ac1906d87d0b1fb9",
+    "b4461614af7aa4da",
+    "b7cd6ef56bd58ced",
+    "b8d858927550a44e"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-137693d1b0ea"
+    "ac1906d87d0b1fb9"
    ],
    "over_budget": {
     "gated": true,
@@ -14622,12 +14622,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-42ebe4a5a547",
-       "s-678c07412350",
-       "s-926a7048323f"
+       "97cdc7c54f2d4f53",
+       "9eeef37ce9a7b298",
+       "e01134ac678f213f"
       ],
       "only_ungated": [
-       "s-226f94fa3135"
+       "b4461614af7aa4da"
       ]
      },
      "rank_diff": {
@@ -14635,17 +14635,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-137693d1b0ea": -7,
-       "s-154f99b8b609": 4,
-       "s-1c9dc0e50707": -7,
-       "s-226f94fa3135": -5,
-       "s-42ebe4a5a547": 4,
-       "s-678c07412350": 4,
-       "s-886b84c78fe0": 3,
-       "s-926a7048323f": 4,
-       "s-b21d7845db34": 3,
-       "s-c7eb78c43d61": -7,
-       "s-f8a2b2ddf8fc": 4
+       "48442654adbb9a19": 3,
+       "4fbc5f30556eb596": 3,
+       "97cdc7c54f2d4f53": 4,
+       "9eeef37ce9a7b298": 4,
+       "ac1906d87d0b1fb9": -7,
+       "acc640da0f02ce33": 4,
+       "b227dcbc07437a5a": 4,
+       "b4461614af7aa4da": -5,
+       "b7cd6ef56bd58ced": -7,
+       "b8d858927550a44e": -7,
+       "e01134ac678f213f": 4
       }
      }
     },
@@ -14661,8 +14661,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-067c2777094f": -1,
-       "u-1bd88cec4a16": 1
+       "1b774d30cf919b53": 1,
+       "775fc7e8b660f7a1": -1
       }
      }
     }
@@ -14676,12 +14676,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "o-40e263",
-    "o-49ce33",
-    "o-81eb14",
-    "r-101643",
-    "s-4debe8",
-    "s-63cd61"
+    "22dbe57d63d3d9f5",
+    "26f6fa2408f0c25a",
+    "2823a6ece20a1346",
+    "2ce4e51fa5a2bcd2",
+    "7ddeb63d4c216df2",
+    "c2a5823f8744ab15"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14715,10 +14715,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-40e263": -1,
-       "o-49ce33": -1,
-       "o-81eb14": -1,
-       "o-da1220": 3
+       "24eb043174236f6c": 3,
+       "26f6fa2408f0c25a": -1,
+       "7ddeb63d4c216df2": -1,
+       "c2a5823f8744ab15": -1
       }
      }
     },
@@ -14734,11 +14734,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-39e5a4": 2,
-       "s-4debe8": -3,
-       "s-63cd61": -3,
-       "s-cf6b7d": 2,
-       "s-d65481": 2
+       "22dbe57d63d3d9f5": -3,
+       "2823a6ece20a1346": -3,
+       "4a9ca35e52cbb59b": 2,
+       "7d90d534cb2c3f82": 2,
+       "d5a57b4f322ca01e": 2
       }
      }
     }
@@ -14752,25 +14752,25 @@
    "n_flipped_items": 20,
    "n_lid_biting_flips": 19,
    "lid_biting_items": [
-    "o-29ba0caf00d3",
-    "r-0069d1a525b6",
-    "r-05b8a287b22c",
-    "r-189298c5383d",
-    "r-2842bba4d93a",
-    "r-51e277464c34",
-    "r-586d2fdf007b",
-    "r-5b5fdf4c7bac",
-    "r-81bcd2e2ee8f",
-    "r-8f19d3ee79db",
-    "r-b38380790026",
-    "s-3cd5d35ca83d",
-    "s-719bd28afde1",
-    "s-8c1fd10b4cc1",
-    "s-8de00f0d46d8",
-    "s-911aacddef5a",
-    "s-b848681872d0",
-    "s-c60f8119d3d6",
-    "s-ea48f74b1729"
+    "0036f17eb686255a",
+    "0a31400896c48f49",
+    "0af1b53acab73fec",
+    "287cbc6014903238",
+    "2ecc1982875f6d73",
+    "3f718b3193799011",
+    "42eb1522de2f6992",
+    "455871a1f9e6ad45",
+    "68b138a2b6c0b9a5",
+    "778145b40c610d58",
+    "81345f03bd5c503f",
+    "89da891b53088aae",
+    "945a9421be3c888e",
+    "9b6982fa013ff486",
+    "a1db43888f6ab006",
+    "d90b0f0596df5a65",
+    "dd86f6ff824d28f0",
+    "f8d1c167647ef127",
+    "f94eadb00bd07403"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14802,10 +14802,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-29ba0caf00d3": -3,
-       "o-55fba15a1ce4": 1,
-       "o-cf107be88478": 1,
-       "o-f6db3a0dd241": 1
+       "69dad54ab472f926": 1,
+       "81345f03bd5c503f": -3,
+       "b918fc165c0eb323": 1,
+       "c9e69501791d2c22": 1
       }
      }
     },
@@ -14821,25 +14821,25 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-15070c5b9c9f": 4,
-       "s-275b931e79b5": 6,
-       "s-3aa4950992c6": 2,
-       "s-3cd5d35ca83d": -3,
-       "s-5c46e8b9dd72": 5,
-       "s-67aba5d9ab04": 3,
-       "s-719bd28afde1": -4,
-       "s-8352a6248c8a": 1,
-       "s-8c1fd10b4cc1": -3,
-       "s-8ca07246e3c9": 2,
-       "s-8de00f0d46d8": -5,
-       "s-911aacddef5a": -2,
-       "s-923514f97262": 2,
-       "s-98103684108e": 6,
-       "s-a11e35a74bbf": 2,
-       "s-b848681872d0": -8,
-       "s-c60f8119d3d6": -9,
-       "s-e4ee695ae89f": 3,
-       "s-ea48f74b1729": -2
+       "1746e0e710909e80": 1,
+       "17e56b0520310511": 6,
+       "1d1aca7ff331ee4b": 2,
+       "22cea428859af26a": 2,
+       "287cbc6014903238": -2,
+       "455871a1f9e6ad45": -3,
+       "68b138a2b6c0b9a5": -8,
+       "726410195de7439b": 3,
+       "7639d38581511bbb": 6,
+       "778145b40c610d58": -9,
+       "8b75414cfbeb5ccb": 2,
+       "945a9421be3c888e": -3,
+       "a1db43888f6ab006": -5,
+       "aba63cc290522366": 3,
+       "b325bc147fed6b6f": 2,
+       "cc978bbb10dda7a2": 4,
+       "d876d54500d9ef33": 5,
+       "d90b0f0596df5a65": -4,
+       "dd86f6ff824d28f0": -2
       }
      }
     }
@@ -14853,10 +14853,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-2301bed4b134",
-    "r-3b2fe98c7c61",
-    "s-1c1e048c2d7d",
-    "s-de0f9e9daeda"
+    "61ea5a614db30a8d",
+    "9c0a038d62f3cd1c",
+    "9f6be1dd6aeb0b31",
+    "af1005c2bc1b68df"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14890,12 +14890,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1c1e048c2d7d": -4,
-       "s-56f7857dd593": 2,
-       "s-587a3095f370": 2,
-       "s-601ff7f04547": 2,
-       "s-73228cd50a2f": 2,
-       "s-de0f9e9daeda": -4
+       "23b597ff4370224e": 2,
+       "61ea5a614db30a8d": -4,
+       "6c83c4a174dbee26": 2,
+       "77ccf4f3983f2d9a": 2,
+       "9f6be1dd6aeb0b31": -4,
+       "a6c7fd3b6c738cb9": 2
       }
      }
     }
@@ -14909,16 +14909,16 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "o-a25007f4c6e3",
-    "r-304a4ed4f0d4",
-    "r-3b021e7ba8c5",
-    "r-4f62fd1dff95",
-    "r-bf4ee92d41bb",
-    "s-15609a6f3c71",
-    "s-4db06d37106e",
-    "s-615b988a4f25",
-    "s-7ac48c95c8b3",
-    "s-a4b2a6e5733c"
+    "089edb92b90c85c1",
+    "356bf23b3ee38af9",
+    "4f6742ed7538a441",
+    "5eac7e58ca460a3a",
+    "66c223ca93a4d551",
+    "6ff087e9b56c2057",
+    "7f5e8cf223609cab",
+    "9850b76e1404be87",
+    "a7f203f4334cf227",
+    "d0080726a7e4e9d9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -14943,10 +14943,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-936972dfead1"
+       "a5ad6282af1c8e46"
       ],
       "only_ungated": [
-       "s-a4b2a6e5733c"
+       "089edb92b90c85c1"
       ]
      },
      "rank_diff": {
@@ -14954,18 +14954,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-06961db383db": 5,
-       "s-15609a6f3c71": -2,
-       "s-4db06d37106e": -4,
-       "s-615b988a4f25": -3,
-       "s-6a6982330cce": 4,
-       "s-7ac48c95c8b3": -4,
-       "s-936972dfead1": 1,
-       "s-9c6e42d76a4a": 5,
-       "s-a4b2a6e5733c": -7,
-       "s-b605da8fdabe": 1,
-       "s-ba9ee60f1393": 1,
-       "s-cbd74b84ec45": 3
+       "089edb92b90c85c1": -7,
+       "08ad8796fdfb1561": 4,
+       "1156c13596559a74": 3,
+       "24356bdea8003818": 1,
+       "28b1d071c5742e74": 1,
+       "4f6742ed7538a441": -3,
+       "5eac7e58ca460a3a": -4,
+       "7ec0b8f5385c5e6c": 5,
+       "7f5e8cf223609cab": -4,
+       "a5ad6282af1c8e46": 1,
+       "bfe8d94193e0c097": 5,
+       "d0080726a7e4e9d9": -2
       }
      }
     }
@@ -14979,15 +14979,15 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "r-11fc7485e0f4",
-    "r-282af288890f",
-    "r-5211744ef5ac",
-    "r-67333332a462",
-    "r-708002f15b35",
-    "r-906e53a26db6",
-    "r-c8ccf8c88ea5",
-    "r-e01f534ebcc0",
-    "s-0cf03c0605e6"
+    "01aad628d68e5ae4",
+    "0289768b7f6e58cb",
+    "3d3dba530a71fbf9",
+    "b3cf0fb9e52840a5",
+    "b763757be3bbbc6d",
+    "c0d2fe521b816ae4",
+    "e672f78b77bee47f",
+    "ebc957648391260b",
+    "fc55c637aca87e1a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15012,10 +15012,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-7d60a789a72e"
+       "3366c8912ade2867"
       ],
       "only_ungated": [
-       "s-0cf03c0605e6"
+       "b763757be3bbbc6d"
       ]
      },
      "rank_diff": {
@@ -15023,12 +15023,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0cf03c0605e6": -5,
-       "s-3c6e73e94951": 1,
-       "s-7d60a789a72e": 1,
-       "s-96497655bd79": 1,
-       "s-bac37138a440": 1,
-       "s-cfbc97e03c7b": 1
+       "3366c8912ade2867": 1,
+       "41f2a9649ac1816f": 1,
+       "97815ae9b94da285": 1,
+       "ae52f293abf18a66": 1,
+       "b763757be3bbbc6d": -5,
+       "c8de7e6269775c11": 1
       }
      }
     }
@@ -15042,14 +15042,14 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-5cb16e67acc5",
-    "r-95628afa5412",
-    "r-a4d478bcb363",
-    "r-d3809a4821f6",
-    "r-e8676744236f",
-    "r-ffaf8f3617e7",
-    "s-11a84d232e72",
-    "s-be1daf56a3ed"
+    "03987297b22fc5b3",
+    "45987a6a859c37e9",
+    "4875cb9d2f416aea",
+    "650d7e6b5440de41",
+    "656a3373733c2965",
+    "7714263562f58d03",
+    "86639611feda8a44",
+    "cbbc97bd77f0cdf7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15081,16 +15081,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-11a84d232e72": -6,
-       "s-1d3b874129b8": 1,
-       "s-2f03e0dc00b8": 1,
-       "s-664704a6f21e": 1,
-       "s-6ea924caad7d": 1,
-       "s-819bd16759cb": 1,
-       "s-be1daf56a3ed": -2,
-       "s-c68961ef5c0f": 1,
-       "s-ed7cd32eedae": 1,
-       "s-f3b77b019d06": 1
+       "189ee8dc8504d41e": 1,
+       "5cd0329369ad0f01": 1,
+       "65bc6497b4594d26": 1,
+       "6eeb85830faa86f1": 1,
+       "86639611feda8a44": -6,
+       "997e7b51ca03a6d0": 1,
+       "b2850297cba93740": 1,
+       "c886951feceb5dbd": 1,
+       "cbbc97bd77f0cdf7": -2,
+       "f94e6d0679050b47": 1
       }
      }
     }
@@ -15104,11 +15104,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "o-e4c698",
-    "r-9bd882",
-    "s-a6ee22",
-    "s-d55712",
-    "s-d61bc4"
+    "234d44a6ce445bb5",
+    "28b85425ae39e73c",
+    "9bbda50cd25b3abd",
+    "9ed6224563a89ccb",
+    "fef8249e93e679d2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15142,11 +15142,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-193f53": 1,
-       "o-194711": 1,
-       "o-6ccd26": 1,
-       "o-bb142d": 1,
-       "o-e4c698": -4
+       "28b85425ae39e73c": -4,
+       "43d3da572b545763": 1,
+       "4bbbc0dd2dfe02e5": 1,
+       "6ad0f908fcae6301": 1,
+       "d0c235399cc8613e": 1
       }
      }
     },
@@ -15162,16 +15162,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-08d541": 2,
-       "s-0e8b7f": 3,
-       "s-330335": 3,
-       "s-93490c": 1,
-       "s-969dad": 3,
-       "s-a6ee22": -7,
-       "s-adea23": 3,
-       "s-d55712": -6,
-       "s-d61bc4": -5,
-       "s-f78537": 3
+       "0cf9a55e2686c68a": 2,
+       "0d4b4a9fa1bab855": 3,
+       "0f21b27b8d755a35": 3,
+       "33a2efcdb2178342": 3,
+       "40129f970be976a8": 1,
+       "508373836eb21de4": 3,
+       "9bbda50cd25b3abd": -6,
+       "9ed6224563a89ccb": -7,
+       "f6b042b20b1a94c0": 3,
+       "fef8249e93e679d2": -5
       }
      }
     }
@@ -15185,7 +15185,7 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-e4c698"
+    "28b85425ae39e73c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15219,8 +15219,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-194711": 1,
-       "o-e4c698": -1
+       "28b85425ae39e73c": -1,
+       "43d3da572b545763": 1
       }
      }
     }
@@ -15234,10 +15234,10 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-a50dbc",
-    "r-bf3b87",
-    "s-4d3d5a",
-    "s-e25412"
+    "0082eb2b76965a21",
+    "871ece82ec0802ca",
+    "aba00fb9f4707cfa",
+    "da6ed0ee225f57db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15271,15 +15271,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0cad78": 2,
-       "s-464a8b": 2,
-       "s-4d3d5a": -6,
-       "s-660d1c": 2,
-       "s-7d05da": 2,
-       "s-aa10d1": 1,
-       "s-cfba59": 1,
-       "s-e25412": -6,
-       "s-f57b52": 2
+       "169433c6966768fe": 2,
+       "16cea4f031248187": 2,
+       "307ec63f94aed7d0": 2,
+       "6c20041eb27e290a": 1,
+       "792cd264cbb0a4d1": 2,
+       "aba00fb9f4707cfa": -6,
+       "da6ed0ee225f57db": -6,
+       "dd4f7854e88d2c12": 2,
+       "e5194e0916c6d1c0": 1
       }
      }
     }
@@ -15293,13 +15293,13 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-0254237fe63d",
-    "r-76962418e0c7",
-    "r-8add52fa0b8c",
-    "r-d068f3add15d",
-    "r-e0065aa0020e",
-    "s-22ca2cf2ea76",
-    "s-da4df0f0f219"
+    "0a4e4130b88c80da",
+    "25623faa9556ce5b",
+    "2635c5dc50af4f02",
+    "50d6106638b3e95f",
+    "a3ac3b6e679ac3ee",
+    "dbc9dd519417cfb4",
+    "fdb23ec323835a31"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15333,17 +15333,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-20e86f4b2932": 2,
-       "s-22ca2cf2ea76": -8,
-       "s-35e2d867f879": 1,
-       "s-671179e6e624": 2,
-       "s-84f4ae66dc81": 2,
-       "s-ae4baed02ad7": 2,
-       "s-bb5e6d7e3771": 2,
-       "s-c2310d1dc76d": 1,
-       "s-c96353813a91": 2,
-       "s-da4df0f0f219": -8,
-       "s-e77099ca114d": 2
+       "0ac96adeefb08be2": 2,
+       "28e787da13971c20": 1,
+       "3adf55bf7f04d076": 2,
+       "43eed6cc4d86b71d": 1,
+       "50d6106638b3e95f": -8,
+       "59c9ded029ff210a": 2,
+       "a3ac3b6e679ac3ee": -8,
+       "c9fdd7eee1419387": 2,
+       "e185da3b81da8078": 2,
+       "ec7d59c876c1de80": 2,
+       "f47b50259dcb2f2f": 2
       }
      }
     }
@@ -15357,11 +15357,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-3abf6d",
-    "r-90a5da",
-    "r-d0f261",
-    "r-f0844e",
-    "s-967200"
+    "4a2b0eec4aa1de01",
+    "4dd63b7f494c5611",
+    "7084c2e02bb796a7",
+    "7e7b9a987bee3cf1",
+    "ddabc2498d65874c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15395,10 +15395,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-034aa1": 1,
-       "s-3cf3c8": 1,
-       "s-65636b": 1,
-       "s-967200": -3
+       "4dd63b7f494c5611": -3,
+       "71c8ab17a5b368db": 1,
+       "bcb3f81b7dbae7cd": 1,
+       "d5cd5f6c7cca1b51": 1
       }
      }
     }
@@ -15412,10 +15412,10 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-06f2de8bb2a2",
-    "r-9951f51f0b4a",
-    "r-b0152344ca63",
-    "s-2ddd1c5dd6b4"
+    "072296392ae9c67a",
+    "c2718ce694474e28",
+    "d2fe68156979f870",
+    "fdecebda7cbf2229"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15447,10 +15447,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1e5b8e69a3cc": 1,
-       "s-2ddd1c5dd6b4": -3,
-       "s-709331af7b9f": 1,
-       "s-a3601f3217d2": 1
+       "072296392ae9c67a": -3,
+       "63a0f180ae3f352b": 1,
+       "a0230d5c6bdb2dc7": 1,
+       "dc5fc40b4506fc29": 1
       }
      }
     }
@@ -15464,14 +15464,14 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-4944b1a41608",
-    "r-59d133b421d9",
-    "r-960f13fcbabd",
-    "r-b521c39f64f4",
-    "s-71ab07e4f94f",
-    "s-ba10bc5455ce",
-    "s-d21851489b7a",
-    "s-de6e6e64a9b9"
+    "3f4629010ff1f1b0",
+    "437ed8ad3cf68ec9",
+    "474c1c4975e89c67",
+    "5f4f798cc846b20d",
+    "60a166bf174c58e1",
+    "8e267eafec3296b4",
+    "dd3a186ef86c59a2",
+    "f5354b220f646835"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15505,23 +15505,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0350664c37c0": 4,
-       "s-0505851d0abe": 4,
-       "s-30d93d834195": 4,
-       "s-3ac67653e89b": 2,
-       "s-3caa96dce1be": 4,
-       "s-3f52c0e71f0e": 4,
-       "s-6387e3a0bdd4": 1,
-       "s-71ab07e4f94f": -10,
-       "s-7988631cdf8f": 4,
-       "s-816437aceaf3": 4,
-       "s-b1ad31c71e80": 4,
-       "s-ba10bc5455ce": -11,
-       "s-be5b954f2907": 4,
-       "s-c814f11cf146": 4,
-       "s-ce268be55866": 1,
-       "s-d21851489b7a": -12,
-       "s-de6e6e64a9b9": -11
+       "0511c43d3385acb7": 4,
+       "109dbc195139c638": 4,
+       "2cd4baad33ed9cd1": 4,
+       "2de5de68b9bd1d0d": 4,
+       "2e47ad0287553183": 4,
+       "3a9a9e08e90713a2": 1,
+       "3dc30adc5222aae8": 4,
+       "3f4629010ff1f1b0": -11,
+       "437ed8ad3cf68ec9": -12,
+       "4ed9c2195ecdc467": 4,
+       "5f4f798cc846b20d": -11,
+       "a34e50b63793ffe2": 4,
+       "b6cff26a31794cd3": 2,
+       "d6c1cf4489ce6719": 4,
+       "dd3a186ef86c59a2": -10,
+       "ec178df275876adf": 1,
+       "edc3fd68d9f9b6ec": 4
       }
      }
     }
@@ -15535,18 +15535,18 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 12,
    "lid_biting_items": [
-    "r-301d432515ea",
-    "r-38326382407d",
-    "r-576e7ef3b1c1",
-    "r-a75c9a485593",
-    "r-c1c11a228909",
-    "r-cab5f655c571",
-    "r-d262d0d0afe7",
-    "r-fc6811606b79",
-    "s-3295458aba4e",
-    "s-3da6234d34f0",
-    "s-c092997c421a",
-    "s-d16ccb3fdda6"
+    "015a4ed3dda44a41",
+    "437eae889f2cf0f1",
+    "4e54d0ec8972eea3",
+    "6c00fb2339ca5890",
+    "7e856f0ffa6a72f9",
+    "9e87625cae85640f",
+    "ac0f4b68db75929b",
+    "b44dab44c45dfe3f",
+    "c2617450abaa5926",
+    "d4be4270a5d138e7",
+    "dcebef48b88ce643",
+    "ec0a7e5454e3ce94"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15571,12 +15571,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-780991314841",
-       "s-dfa833260b94"
+       "494270f945e94ac6",
+       "58c315f7532ce41b"
       ],
       "only_ungated": [
-       "s-c092997c421a",
-       "s-d16ccb3fdda6"
+       "4e54d0ec8972eea3",
+       "d4be4270a5d138e7"
       ]
      },
      "rank_diff": {
@@ -15584,17 +15584,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0496933196ef": 4,
-       "s-3295458aba4e": -7,
-       "s-3da6234d34f0": -5,
-       "s-3ece4db0f5d8": 4,
-       "s-493833485fa9": 4,
-       "s-780991314841": 3,
-       "s-ac2a9fdb249e": 4,
-       "s-c092997c421a": -7,
-       "s-d16ccb3fdda6": -7,
-       "s-d98e849461e7": 4,
-       "s-dfa833260b94": 3
+       "015a4ed3dda44a41": -7,
+       "494270f945e94ac6": 3,
+       "4a3eeaf9e62295db": 4,
+       "4e54d0ec8972eea3": -7,
+       "58c315f7532ce41b": 3,
+       "64715c4f5934474a": 4,
+       "7fd1c6726e616908": 4,
+       "b9d34f686da63534": 4,
+       "c2617450abaa5926": -5,
+       "c7df50caa4a9bbdf": 4,
+       "d4be4270a5d138e7": -7
       }
      }
     }
@@ -15608,9 +15608,9 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "s-531ef892c6e6",
-    "s-8e9563712806",
-    "s-c72d74c5b78e"
+    "696263278061630a",
+    "e1ad57b4e0f3e81c",
+    "eddb659d8162d498"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15635,12 +15635,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-b7834ea83855",
-       "s-d05211b0f977"
+       "1e67f9a6c2ece048",
+       "94d95c6384ef0561"
       ],
       "only_ungated": [
-       "s-531ef892c6e6",
-       "s-8e9563712806"
+       "696263278061630a",
+       "e1ad57b4e0f3e81c"
       ]
      },
      "rank_diff": {
@@ -15648,18 +15648,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-25ddef32300f": 3,
-       "s-531ef892c6e6": -9,
-       "s-789f2eba42a9": 2,
-       "s-893f156a058b": 3,
-       "s-8e9563712806": -8,
-       "s-996af3e91785": 2,
-       "s-af94c19832d9": 2,
-       "s-b7834ea83855": 2,
-       "s-c72d74c5b78e": -3,
-       "s-d05211b0f977": 2,
-       "s-e3cef8cb1f5f": 1,
-       "s-e78f56815e0d": 3
+       "1e67f9a6c2ece048": 2,
+       "2404e32fe3c65735": 2,
+       "3679c083aed7d8d8": 1,
+       "696263278061630a": -8,
+       "6e13eff44acd176a": 3,
+       "743890914eb8b417": 2,
+       "91a681501ac8a922": 3,
+       "94d95c6384ef0561": 2,
+       "b155cfe48d56bd70": 2,
+       "b4e9088f7890d319": 3,
+       "e1ad57b4e0f3e81c": -9,
+       "eddb659d8162d498": -3
       }
      }
     }
@@ -15673,16 +15673,16 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-1b60e8",
-    "r-4444a7",
-    "r-65ca04",
-    "r-b03ffe",
-    "s-2be4b9",
-    "s-65fe6a"
+    "08731e33d1e4dff1",
+    "0f8c946bb2e776ed",
+    "1182933876ef7384",
+    "358802f10ea683de",
+    "5eee2757170dbd7f",
+    "ac88d32948bd4220"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "s-2be4b9"
+    "0f8c946bb2e776ed"
    ],
    "over_budget": {
     "gated": true,
@@ -15714,21 +15714,21 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-167f0a": 1,
-       "s-26f8d0": 1,
-       "s-2be4b9": -9,
-       "s-392b90": 1,
-       "s-574fdb": 1,
-       "s-65fe6a": -4,
-       "s-72185e": 1,
-       "s-77514b": 1,
-       "s-815fee": 1,
-       "s-9127f8": 1,
-       "s-a18f52": 1,
-       "s-ac7bf2": 1,
-       "s-b0c9e8": 1,
-       "s-e39f39": 1,
-       "s-f56a9e": 1
+       "0011fc7dad2ce180": 1,
+       "0f8c946bb2e776ed": -9,
+       "1e209c8bb2207956": 1,
+       "2deb2609a2579a2b": 1,
+       "556bdba7919410bb": 1,
+       "5eee2757170dbd7f": -4,
+       "8b3be9c58f4f22c4": 1,
+       "8dda3b958b7ac564": 1,
+       "9e0edc6da5724e80": 1,
+       "b6917b197384adc5": 1,
+       "bb690e2039317b27": 1,
+       "c881daa5b02bc7a5": 1,
+       "dcb4702e53dc4bf7": 1,
+       "dcbd26b73cc60d90": 1,
+       "eb6585bdc82f149b": 1
       }
      }
     }
@@ -15742,14 +15742,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-c925d8a4423a",
-    "r-f556baf532ea",
-    "s-0f74a12bfd0b",
-    "s-7dfd3b7cf2f9",
-    "s-7f53e8bcbeba",
-    "s-a28aa1df858e",
-    "s-c06847922980",
-    "s-e717a4751ff2"
+    "06aa884e7273c7a4",
+    "3be74223c6b2df4c",
+    "49dd832024dd8db2",
+    "c640c92cf0592b86",
+    "ca18dca238201f73",
+    "cc31f6ab78b66c11",
+    "d6415232e7065c46",
+    "de71dba682f6e105"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15783,33 +15783,33 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0f74a12bfd0b": -13,
-       "s-116febbe5090": 1,
-       "s-168222bd9a81": 6,
-       "s-1cf19b431a5a": 1,
-       "s-538633e383ef": 2,
-       "s-75633cacfb2d": 6,
-       "s-7dfd3b7cf2f9": -13,
-       "s-7eff17f03078": 6,
-       "s-7f53e8bcbeba": -18,
-       "s-8f1498e8327b": 2,
-       "s-992408c71add": 4,
-       "s-9cce4230b265": 6,
-       "s-9fbfc5845461": 6,
-       "s-a28aa1df858e": -9,
-       "s-a56b787a55d6": 5,
-       "s-ab306da3a5ec": 5,
-       "s-c06847922980": -13,
-       "s-c1413ea4c774": 6,
-       "s-cc61caac48fe": 2,
-       "s-d0ab6b50d0fa": 4,
-       "s-d6fd5cb63d00": 2,
-       "s-d71485edae2d": 1,
-       "s-d8fad009d8cc": 5,
-       "s-da5ba7591668": 5,
-       "s-e717a4751ff2": -16,
-       "s-f9308ac9dacc": 5,
-       "s-fb51a74437e8": 2
+       "06aa884e7273c7a4": -13,
+       "0b6b5e064b5089ab": 2,
+       "0f59feedfccb4d37": 6,
+       "283a5fea3f40f96e": 5,
+       "3be74223c6b2df4c": -13,
+       "4195a203afd5f143": 5,
+       "47c8c03ae7e12404": 6,
+       "49dd832024dd8db2": -9,
+       "4f920686761f740d": 1,
+       "57174615461bae68": 4,
+       "5e3174c297f43405": 1,
+       "6d9771c142c33a18": 6,
+       "714aaff6889eb33e": 5,
+       "722428943ce15ef7": 2,
+       "7695497b76e3e447": 1,
+       "961fd97287b81aad": 2,
+       "968303f381c95f24": 6,
+       "9faefdb5736e2ee7": 5,
+       "a0f18133a9d597a9": 5,
+       "aa994b54a71a20ae": 6,
+       "aeb1e587b28d3445": 6,
+       "b288d7630459f090": 2,
+       "b32ce8fde7c4f35c": 2,
+       "c640c92cf0592b86": -16,
+       "cc31f6ab78b66c11": -13,
+       "de71dba682f6e105": -18,
+       "ebfe31243736f1d4": 4
       }
      }
     }
@@ -15823,11 +15823,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "o-133a2ace9130",
-    "o-884d28597791",
-    "r-62075dfde769",
-    "r-ce71a13a7c1c",
-    "s-d59bfdb345e0"
+    "0169839b7368499c",
+    "12526009f8c86c4b",
+    "29e5005b2b813524",
+    "be60fafab50d171b",
+    "fc3f0670e759a51f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15859,8 +15859,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-133a2ace9130": -1,
-       "o-ca29e02eebdf": 1
+       "0169839b7368499c": -1,
+       "942991972402eafa": 1
       }
      }
     },
@@ -15876,14 +15876,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-410e4b9bb418": 1,
-       "s-453df44b60fc": 1,
-       "s-602e1f3cf22a": 1,
-       "s-78b76ad5f725": 1,
-       "s-8a63b3b25c59": 1,
-       "s-aecaa92fd59c": 1,
-       "s-d59bfdb345e0": -7,
-       "s-fdd7cb10f879": 1
+       "05f3a556a7bc8468": 1,
+       "12526009f8c86c4b": -7,
+       "15b146dcb66377e6": 1,
+       "2fb471e3c73d7756": 1,
+       "661b75601d3554a9": 1,
+       "ab429f2938286c02": 1,
+       "bb38a4af7fa8c63a": 1,
+       "bf86994dd30f2565": 1
       }
      }
     }
@@ -15897,12 +15897,12 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-2c6bfd640474",
-    "r-2cfd99886915",
-    "r-cbb8e6798a8f",
-    "r-dda72a321849",
-    "r-fdaa730b26e3",
-    "s-95a34473f0db"
+    "3a170d4872eabec5",
+    "9b5c1586dd5c6159",
+    "ab4df7e68405bd81",
+    "ad6aafa795dd611c",
+    "e4fa8614d94325d9",
+    "e71103997040055c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -15927,10 +15927,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-9e25870ae5a7"
+       "6cb1402e5a48c06d"
       ],
       "only_ungated": [
-       "s-95a34473f0db"
+       "ad6aafa795dd611c"
       ]
      },
      "rank_diff": {
@@ -15938,16 +15938,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0a0b9409d089": 1,
-       "s-1d844919adbe": 1,
-       "s-30dbf21dc389": 1,
-       "s-3afe38c7b37b": 1,
-       "s-4cc18a4f504b": 1,
-       "s-8c79a4474cb7": 1,
-       "s-95a34473f0db": -9,
-       "s-9e25870ae5a7": 1,
-       "s-a2daf26de8e8": 1,
-       "s-c9709620a88b": 1
+       "015d6de362f5f4a6": 1,
+       "1a653ed5d899c6fd": 1,
+       "3959d27f250dbc91": 1,
+       "617ff8f5a5bc9e67": 1,
+       "691652c0e1632278": 1,
+       "6cb1402e5a48c06d": 1,
+       "905578a23cd164eb": 1,
+       "9509ad440f4ca388": 1,
+       "ad6aafa795dd611c": -9,
+       "b3bce227f645d6a3": 1
       }
      }
     }
@@ -15961,17 +15961,17 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-357a55bf969e",
-    "r-439994898d30",
-    "r-48c19eb2fcaa",
-    "r-4918ca25b1d6",
-    "r-d2155712ed90",
-    "r-dda6532bd12f",
-    "s-a9f68c54255a"
+    "553243ef1857ea7d",
+    "638dc06ce2336bf3",
+    "7427aeb7f2b18e14",
+    "7662fc16992ed24e",
+    "ca6fc6e28118384b",
+    "d817417605d9b36e",
+    "f5e71568e4539fe6"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-357a55bf969e"
+    "d817417605d9b36e"
    ],
    "over_budget": {
     "gated": true,
@@ -16001,12 +16001,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3fb14b462a94": 1,
-       "s-40cb112effed": 1,
-       "s-7202da8288ec": 1,
-       "s-a9f68c54255a": -5,
-       "s-b2a3649f4138": 1,
-       "s-bed5368993d8": 1
+       "16942cc85fbde051": 1,
+       "553243ef1857ea7d": -5,
+       "a0a45b18848482d8": 1,
+       "b6a24f5ec8448e89": 1,
+       "e4dbc665e1f0db93": 1,
+       "e7216bd90df44ae3": 1
       }
      }
     }
@@ -16020,19 +16020,19 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 13,
    "lid_biting_items": [
-    "h:4cbf0acbdd73",
-    "o-5b8df357c64d",
-    "r-01e87a33ad7a",
-    "r-05d4d3cb90ce",
-    "r-498681ab50a8",
-    "r-622ee6d6c2ed",
-    "r-782c8a1e7971",
-    "r-78726d23d29e",
-    "r-98f6a04559e7",
-    "r-c68c7be529ff",
-    "r-cfa70b9c6559",
-    "s-3662aca3c5e6",
-    "s-f1d0e84ff346"
+    "0c8efd2fa37df24e",
+    "3de5c6898d307441",
+    "5508637f7c79ffca",
+    "590188768634d4a7",
+    "a6cc10956e30bed2",
+    "aaa999a8c820216a",
+    "aff3c5e6b7e984d6",
+    "b1392ae95561c562",
+    "b897ab877b60b76e",
+    "c3844f4df56cfab8",
+    "e5599b7f20376bfe",
+    "ebeb979a52b27a0b",
+    "efe815aae3282264"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16064,9 +16064,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-46389c74b8fe": 1,
-       "o-5b8df357c64d": -2,
-       "o-9ac19e49ba62": 1
+       "a37877a42a85a1d7": 1,
+       "a6cc10956e30bed2": -2,
+       "f519f30a971a3c8f": 1
       }
      }
     },
@@ -16082,10 +16082,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-6427f5243dfa": 1,
-       "s-7233d967d13e": 1,
-       "s-a2250fe46105": 1,
-       "s-f1d0e84ff346": -3
+       "007204cf9a7c3e81": 1,
+       "8d417fdf1afd7481": 1,
+       "c3844f4df56cfab8": -3,
+       "c7d9a1e6dc951908": 1
       }
      }
     }
@@ -16099,9 +16099,9 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-0cf43d70571a",
-    "r-21ccad63cc49",
-    "s-45ec593266f0"
+    "80464f9b1199076c",
+    "bcc1eebc46db9d19",
+    "f61520969772a627"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16135,10 +16135,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0c42801d301e": 1,
-       "s-45ec593266f0": -3,
-       "s-a8d977c0c397": 1,
-       "s-fb9a5c077e10": 1
+       "85027c63020f18d9": 1,
+       "88d10d472f91ab97": 1,
+       "9ea11b12fa3434a5": 1,
+       "bcc1eebc46db9d19": -3
       }
      }
     }
@@ -16152,7 +16152,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-4f8ec49e308e"
+    "cca617c0dffdad35"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16180,8 +16180,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1d84784f5ca3": 1,
-       "s-4f8ec49e308e": -1
+       "8838c98114ebe3b1": 1,
+       "cca617c0dffdad35": -1
       }
      }
     }
@@ -16195,16 +16195,16 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "o-23f095b8d292",
-    "r-b9f59a1eff45",
-    "r-ff33b95a9dfa",
-    "s-03e71c64813e",
-    "s-31219f6ec851",
-    "s-c506ebc6287e"
+    "89e93e9b6e61cf13",
+    "9481ac6966284893",
+    "9e3fef12f774af81",
+    "d179158cdd53ced6",
+    "dc2571fb45e3b8e8",
+    "ff3e014736369d62"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-b9f59a1eff45"
+    "89e93e9b6e61cf13"
    ],
    "over_budget": {
     "gated": true,
@@ -16227,13 +16227,13 @@
      "cap_crossings": {
       "count": 5,
       "only_gated": [
-       "s-35f32a0ea42c",
-       "s-c6362fdd9404",
-       "s-d3ef514fdbdf"
+       "4215fdd25dcbda7a",
+       "584e97bb58acfe15",
+       "da58e983bba88e7f"
       ],
       "only_ungated": [
-       "s-03e71c64813e",
-       "s-31219f6ec851"
+       "9e3fef12f774af81",
+       "dc2571fb45e3b8e8"
       ]
      },
      "rank_diff": {
@@ -16241,16 +16241,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-03e71c64813e": -7,
-       "s-31219f6ec851": -7,
-       "s-35f32a0ea42c": 3,
-       "s-37cbdc17aa68": 3,
-       "s-4e5907854c7b": 3,
-       "s-79c80a00b71b": 3,
-       "s-c506ebc6287e": -7,
-       "s-c6362fdd9404": 3,
-       "s-d3ef514fdbdf": 3,
-       "s-e6822c584547": 3
+       "0357becdb52c55c7": 3,
+       "1978a3801ac99d2f": 3,
+       "33e5f5456197110e": 3,
+       "4215fdd25dcbda7a": 3,
+       "584e97bb58acfe15": 3,
+       "9481ac6966284893": -7,
+       "9e3fef12f774af81": -7,
+       "da58e983bba88e7f": 3,
+       "dc2571fb45e3b8e8": -7,
+       "dd016daae9c5a9ce": 3
       }
      }
     }
@@ -16264,12 +16264,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-49d4f9",
-    "r-93be30",
-    "r-ca178e",
-    "r-fdbba6",
-    "s-0af651",
-    "s-b98849"
+    "390f60ce859908da",
+    "89bbc81016af7136",
+    "9bd32130cb7d5ec5",
+    "ac99930b2c2fbdfa",
+    "c1f0294612f9cbec",
+    "d3a2d5d45406a4ee"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16297,12 +16297,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0af651": -2,
-       "s-0c4c27": 1,
-       "s-246e2b": 1,
-       "s-5f8192": 1,
-       "s-8d6cb3": 1,
-       "s-b98849": -2
+       "1547aefcac7435ea": 1,
+       "390f60ce859908da": -2,
+       "89bbc81016af7136": -2,
+       "a0376801e6e7c551": 1,
+       "db8b31720c97073f": 1,
+       "f2ad897006d9b76b": 1
       }
      }
     }
@@ -16316,13 +16316,13 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-267c6fd10a4d",
-    "r-3dcce53710ee",
-    "r-40e01b83195d",
-    "r-593717d8006e",
-    "r-f526da0b5152",
-    "r-feb10d813c69",
-    "s-f96512e8679d"
+    "3101f930945108c0",
+    "33069178fd0dec24",
+    "54c3c0c378d3b511",
+    "673fc38b690305f2",
+    "a4961fb7b4d0a224",
+    "dcf2a50c6c8e6ae7",
+    "f5a1fb7ba7c38052"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16356,15 +16356,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-012372b269d9": 1,
-       "s-1892704c626c": 1,
-       "s-1d77f9c2c243": 1,
-       "s-250d4b668182": 1,
-       "s-4868da890c04": 1,
-       "s-a4bd656d2eb4": 1,
-       "s-e2b1910111d3": 1,
-       "s-f4f04a035922": 1,
-       "s-f96512e8679d": -8
+       "073bf6bae8892a99": 1,
+       "0855a6c38da3d482": 1,
+       "33069178fd0dec24": -8,
+       "3816a36aabb453e9": 1,
+       "48a17436a2cd8c4f": 1,
+       "5a28b1e8d1b73bbb": 1,
+       "637d6e25e1a5744e": 1,
+       "82147d2f2c91e6e5": 1,
+       "b6830327900c4a8b": 1
       }
      }
     }
@@ -16378,11 +16378,11 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "o-0c534ec233e5",
-    "s-2cc172cfb276",
-    "s-43dba42d9c9b",
-    "s-a58bb909c4eb",
-    "s-f8968b74104d"
+    "3c399ddb608cf8a6",
+    "5a1889e221e2fe32",
+    "60398463bc156137",
+    "887ae7d474c19c1f",
+    "f4c30fd95588b74b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16416,8 +16416,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-0c534ec233e5": -1,
-       "o-ab45356f01bb": 1
+       "5a1889e221e2fe32": -1,
+       "e36ac2e638ef7c73": 1
       }
      }
     },
@@ -16433,15 +16433,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-09d5ee757f1f": 3,
-       "s-2cc172cfb276": -1,
-       "s-3a111d158a31": 1,
-       "s-3bc4dcee0111": 1,
-       "s-3d1f5132ef42": 4,
-       "s-43dba42d9c9b": -5,
-       "s-a58bb909c4eb": -2,
-       "s-bdef55880e16": 1,
-       "s-f8968b74104d": -2
+       "227303076c2854b4": 3,
+       "3c399ddb608cf8a6": -5,
+       "49cb70a429ba880f": 1,
+       "60398463bc156137": -2,
+       "887ae7d474c19c1f": -2,
+       "c4b48b8572d20c46": 1,
+       "e2e35f76f92ad28e": 4,
+       "e3ca72785e8db5bd": 1,
+       "f4c30fd95588b74b": -1
       }
      }
     }
@@ -16455,16 +16455,16 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 10,
    "lid_biting_items": [
-    "h:98c728648315",
-    "o-b0e282",
-    "o-b5bf12",
-    "o-efa5bd",
-    "r-0b5986",
-    "r-50c6e1",
-    "r-6e5ba4",
-    "r-92c441",
-    "r-ace97a",
-    "r-d94980"
+    "219563d9bc5fc0f7",
+    "36d5199839e94677",
+    "75cd2e0758017e5f",
+    "92b47ca4650db439",
+    "93eac0a566a25a22",
+    "c4fed69a9fdcf647",
+    "ce2a3e51cca8eb58",
+    "dc2a9206775677d4",
+    "e0135230647ea8e6",
+    "e9226731a1b669a8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16496,16 +16496,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-079fca": 1,
-       "o-0c6bf1": 1,
-       "o-0eeaed": 2,
-       "o-4987c0": 3,
-       "o-9ad8c1": 2,
-       "o-b0e282": -5,
-       "o-b5bf12": -3,
-       "o-efa5bd": -6,
-       "o-f90f0c": 2,
-       "o-fc5797": 3
+       "09344e3dc90fb28e": 1,
+       "0e3020e8cf0bf302": 2,
+       "26cd3e3a190c5158": 2,
+       "75d59b0fc9e7ceaf": 3,
+       "94393a59f71a093c": 1,
+       "a51b6219c30cd6d6": 2,
+       "c31d65c94dd434eb": 3,
+       "c4fed69a9fdcf647": -6,
+       "dc2a9206775677d4": -5,
+       "e9226731a1b669a8": -3
       }
      }
     }
@@ -16519,8 +16519,8 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-b0e282",
-    "o-b5bf12"
+    "dc2a9206775677d4",
+    "e9226731a1b669a8"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16552,8 +16552,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-b0e282": -1,
-       "o-f90f0c": 1
+       "26cd3e3a190c5158": 1,
+       "dc2a9206775677d4": -1
       }
      }
     }
@@ -16567,20 +16567,20 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 14,
    "lid_biting_items": [
-    "o-180dcf",
-    "r-18bcad",
-    "r-414bfa",
-    "r-507507",
-    "r-6b7afa",
-    "r-7b54b0",
-    "r-9f4bc7",
-    "r-b6b229",
-    "r-c762a6",
-    "r-d1d479",
-    "r-f9a267",
-    "s-05e0ee",
-    "s-17d2fe",
-    "s-9be302"
+    "3b7f7a6cdf4392c0",
+    "3ccc3df6a425e6a4",
+    "6f23da17fa0662ac",
+    "889f727c81e9ffa3",
+    "9976d9c12c42df58",
+    "af4ce691de872438",
+    "b8f801072ac48827",
+    "c27c1189739ecef8",
+    "c5b9e649574189da",
+    "c92b48f1cb585826",
+    "cce09ece3e5e6da7",
+    "d2c64ba0361a07f1",
+    "d4c7a16ea14a4a12",
+    "f60c60c9f1e48159"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16608,10 +16608,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-180dcf": -3,
-       "o-7dc360": 1,
-       "o-a2200e": 1,
-       "o-ce8dda": 1
+       "348c72d4776fb12b": 1,
+       "6187cb1a3f32c8d6": 1,
+       "6c1964c00a5f3e34": 1,
+       "af4ce691de872438": -3
       }
      }
     },
@@ -16627,13 +16627,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-05e0ee": -4,
-       "s-145b49": 2,
-       "s-17d2fe": -1,
-       "s-4422f2": 2,
-       "s-8e144a": 2,
-       "s-9be302": -4,
-       "s-dc9601": 3
+       "3ccc3df6a425e6a4": -4,
+       "5f8ef23cca552bce": 2,
+       "6f23da17fa0662ac": -4,
+       "73522d502e8421cc": 2,
+       "bcc057feeb4ebc85": 3,
+       "c27c1189739ecef8": -1,
+       "e08a1045627bf1d5": 2
       }
      }
     }
@@ -16647,7 +16647,7 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-180dcf"
+    "af4ce691de872438"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16675,8 +16675,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-180dcf": -1,
-       "o-a2200e": 1
+       "6c1964c00a5f3e34": 1,
+       "af4ce691de872438": -1
       }
      }
     }
@@ -16690,7 +16690,7 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-daed0f658c5d"
+    "02cc9219d200ce16"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16722,13 +16722,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-5d34bcc9892e": 1,
-       "s-832f0be559ce": 1,
-       "s-ad965b1f7c6a": 1,
-       "s-cae2c9fb82d9": 1,
-       "s-cbc33de4ec08": 1,
-       "s-daed0f658c5d": -6,
-       "s-f4d14df85336": 1
+       "02cc9219d200ce16": -6,
+       "16665d212dafced7": 1,
+       "194821418f07d1fc": 1,
+       "6404532f036fdffc": 1,
+       "891f9e7c4cea8dfa": 1,
+       "9db411f7c7eaf45e": 1,
+       "c0b5b36e07173862": 1
       }
      }
     }
@@ -16742,12 +16742,12 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-1fd8f63ffc9a",
-    "r-50d6258c2050",
-    "r-64cc8d3673e9",
-    "s-5b8463ca4c3b",
-    "s-612b1eecc162",
-    "s-e2fded700c7a"
+    "2f8e0d5f6f14a8e5",
+    "6ca9748e13ea246e",
+    "79c3e7de5c82b64f",
+    "8d289ec47bf916f0",
+    "d8b0ed5319deb13e",
+    "e4f99c1569f4bc17"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16779,12 +16779,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2dc093e62750": 3,
-       "s-4eff64efc019": 2,
-       "s-5b8463ca4c3b": -2,
-       "s-612b1eecc162": -3,
-       "s-8140031f08ec": 3,
-       "s-e2fded700c7a": -3
+       "09ba55ff91c79caf": 3,
+       "67316c64e4a8ffdd": 2,
+       "6ca9748e13ea246e": -3,
+       "b6fdb569096088bc": 3,
+       "d8b0ed5319deb13e": -2,
+       "e4f99c1569f4bc17": -3
       }
      }
     }
@@ -16798,8 +16798,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-6e3ba8",
-    "s-c6a909"
+    "bae25eb790a3e932",
+    "efd67502adf80de9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16835,14 +16835,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-363d02": 1,
-       "s-55b441": 1,
-       "s-6b2ef3": 1,
-       "s-6e3ba8": -3,
-       "s-a0077c": 2,
-       "s-c2c30d": 1,
-       "s-c6a909": -5,
-       "s-e0e79d": 2
+       "0849f8930a43aae5": 1,
+       "646dee1416c91fda": 2,
+       "a5a2168597bfe42b": 1,
+       "bae25eb790a3e932": -3,
+       "bf96b62c5ab4aca1": 1,
+       "cbabf96949d28117": 2,
+       "efd67502adf80de9": -5,
+       "f58652b24b57d905": 1
       }
      }
     }
@@ -16856,13 +16856,13 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-0496d1f19a31",
-    "r-32d7432bf727",
-    "r-3df311005ec6",
-    "r-446ab004f7e9",
-    "r-d5ee48980e16",
-    "r-e1669d5e6595",
-    "s-c5057475566f"
+    "07ea3c9d829cdfcc",
+    "094c27169cb6b567",
+    "156442289dab3b86",
+    "24640d34fffd1b5d",
+    "30d70009484f45c4",
+    "dac586dafac6233a",
+    "fda1370987bdbf00"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16896,13 +16896,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-24e32c57826f": 1,
-       "s-65723f387976": 1,
-       "s-706e60491bd3": 1,
-       "s-70e27d904901": 1,
-       "s-84a5159ef514": 1,
-       "s-8cb3cd148b2f": 1,
-       "s-c5057475566f": -6
+       "07ea3c9d829cdfcc": -6,
+       "149c5fc6d2753cf4": 1,
+       "35c580c31514e534": 1,
+       "505a927227185ce9": 1,
+       "800ca3f0bf539b90": 1,
+       "99fa12788dfd3290": 1,
+       "a70a8a0881c945eb": 1
       }
      }
     }
@@ -16916,13 +16916,13 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 7,
    "lid_biting_items": [
-    "r-0c2dc34297ee",
-    "r-5a46198e7b74",
-    "r-cbbe5d6f8ee6",
-    "s-5328b860bc11",
-    "s-6747e9a8ebce",
-    "s-7a97934db526",
-    "s-d235aabc2a25"
+    "39c53835dba1ad56",
+    "456db09fba55dd0d",
+    "60fb582a1141a424",
+    "6ea9cb5251ca800d",
+    "912aec01ce267f0f",
+    "98f20d8ff37edf2b",
+    "a3f93f3769d04f93"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -16947,10 +16947,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-e2265b25dce0"
+       "211b1153c572919f"
       ],
       "only_ungated": [
-       "s-d235aabc2a25"
+       "6ea9cb5251ca800d"
       ]
      },
      "rank_diff": {
@@ -16958,18 +16958,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0ea74cf0c460": 1,
-       "s-1e65bdc15dc6": 2,
-       "s-5328b860bc11": -4,
-       "s-57cda32501ae": 2,
-       "s-6747e9a8ebce": -4,
-       "s-6ef68ba99d2d": 4,
-       "s-71c3e4ab1769": 2,
-       "s-7a97934db526": -4,
-       "s-ab47672280fe": 2,
-       "s-cbf1f91a592d": 2,
-       "s-d235aabc2a25": -5,
-       "s-e2265b25dce0": 2
+       "211b1153c572919f": 2,
+       "2237a1a46fcd9f62": 1,
+       "34471408d7e18acc": 2,
+       "3f6064a9230c9668": 2,
+       "513757f89a16f307": 2,
+       "6ea9cb5251ca800d": -5,
+       "912aec01ce267f0f": -4,
+       "95afb3702574dbca": 4,
+       "98f20d8ff37edf2b": -4,
+       "a3f93f3769d04f93": -4,
+       "a80068f018c64df2": 2,
+       "c81e54c448b3825e": 2
       }
      }
     }
@@ -16983,12 +16983,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-2d020b949dbc",
-    "r-7e24bd6465dc",
-    "r-a5523f86f1a4",
-    "s-6ae963013055",
-    "s-afec8af1c86b",
-    "s-f252fc69809a"
+    "2d35c48d9d41a585",
+    "6e04a733d8641d94",
+    "a1cf0930bb8b32cc",
+    "a59182687851a7e4",
+    "ac3580124c619d2d",
+    "fab80dab1616871d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17022,17 +17022,17 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0ac6bfc8327d": 2,
-       "s-29dfb554df20": 2,
-       "s-4de58148c54e": 2,
-       "s-6ae963013055": -5,
-       "s-89c142d1d7d4": 1,
-       "s-a281dcd52243": 1,
-       "s-a2b89f9e6c7e": 2,
-       "s-afec8af1c86b": -5,
-       "s-b33aaeb8f388": 2,
-       "s-c07796c624da": 1,
-       "s-f252fc69809a": -3
+       "3c30dd57026f5106": 1,
+       "4f7060027e06bd6b": 2,
+       "527b09c994738500": 2,
+       "6e04a733d8641d94": -5,
+       "74701031fe4eff71": 1,
+       "a1cf0930bb8b32cc": -3,
+       "a299675954511595": 2,
+       "a59182687851a7e4": -5,
+       "d9bf58c04866ddd9": 2,
+       "ea2e68572c6a539d": 1,
+       "f0dd47c3165b0389": 2
       }
      }
     }
@@ -17046,20 +17046,20 @@
    "n_flipped_items": 17,
    "n_lid_biting_flips": 14,
    "lid_biting_items": [
-    "h:4ad62bdf2f80",
-    "o-e41361fec573",
-    "r-32a35fb91846",
-    "r-3a3bf95de863",
-    "r-53fcec27720d",
-    "r-5be93d88e5d5",
-    "r-5fcf62787c23",
-    "r-8b813bf17469",
-    "r-995da7e9e75c",
-    "r-9aff256eb553",
-    "r-ba1974ad30c0",
-    "r-bb44d9241c4c",
-    "r-e5b05d0c560b",
-    "r-f11084d4be04"
+    "0a90eb24cbb5baad",
+    "1b27c750dcc6eb4a",
+    "24c753c3372760c5",
+    "54d5ad2507d06b29",
+    "55c9a823844463f7",
+    "816acb6094e3b07f",
+    "83fd1993ed61321e",
+    "8b80675ae2693863",
+    "905eab0cde28b2ce",
+    "af9deacd981fb160",
+    "c77d5d1db1331cfb",
+    "cecca0bb5c9df058",
+    "e332d7efe4d95307",
+    "f07899f977ae3b38"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17093,10 +17093,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-10c641ba515b": 1,
-       "o-626bed186bfc": 1,
-       "o-c911ee26435c": 1,
-       "o-e41361fec573": -3
+       "56faae98b98b4610": 1,
+       "7487469f219d6b4c": 1,
+       "a42602c4a66ff390": 1,
+       "f07899f977ae3b38": -3
       }
      }
     }
@@ -17110,9 +17110,9 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-1b13d3b836cf",
-    "r-603e6405f0a4",
-    "s-dd82e069f3d7"
+    "583b36ff282f5547",
+    "98b3fcee12b67c8e",
+    "dacc75208a8f2b1c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17144,9 +17144,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-b233c35aa060": 1,
-       "s-ce3701c060c0": 1,
-       "s-dd82e069f3d7": -2
+       "31901303b87e26a7": 1,
+       "36c115336df69cc9": 1,
+       "dacc75208a8f2b1c": -2
       }
      }
     }
@@ -17160,14 +17160,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-5a94a45bcd16",
-    "r-6051b21017c8",
-    "r-76d23797791e",
-    "s-0c405f09782f",
-    "s-677b85a59ab6",
-    "s-7322df280183",
-    "s-85bb5373e5f8",
-    "u-4c3f43b9e992"
+    "0c3a27001c628195",
+    "1b7bfd8835546b3f",
+    "27b54e7bdda84fcc",
+    "4adcc9a62230858d",
+    "526ea4a679ef3247",
+    "68a8267097f5d572",
+    "7389a8b9c2f3d0cc",
+    "7c17d6d0e3ab340f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17192,10 +17192,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-030f533cdcfd"
+       "8a90057f556526a7"
       ],
       "only_ungated": [
-       "s-0c405f09782f"
+       "68a8267097f5d572"
       ]
      },
      "rank_diff": {
@@ -17203,18 +17203,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-030f533cdcfd": 1,
-       "s-04f6eec35c08": 3,
-       "s-05e99d8dd04d": 1,
-       "s-0c405f09782f": -6,
-       "s-15cc5416834e": 2,
-       "s-57f55bb7cf90": 2,
-       "s-5de8011a6c6e": 2,
-       "s-677b85a59ab6": -2,
-       "s-7322df280183": -4,
-       "s-85bb5373e5f8": -5,
-       "s-ddc5a1cc83d5": 3,
-       "s-e150555b2e1e": 3
+       "0c3a27001c628195": -2,
+       "1b7bfd8835546b3f": -4,
+       "3fd80fa2cc765e36": 2,
+       "526ea4a679ef3247": -5,
+       "62a6c19042b761bc": 3,
+       "68a8267097f5d572": -6,
+       "8a90057f556526a7": 1,
+       "a9362f06b110f041": 2,
+       "b947d480e694a572": 3,
+       "e45ca537a48503be": 3,
+       "ea87c9755bdbc750": 2,
+       "f2f5cfe046ab32f8": 1
       }
      }
     }
@@ -17228,12 +17228,12 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "h:b21b3b7619e9",
-    "o-6fa594f32a8b",
-    "r-6bcba44cdda5",
-    "r-78ced05ab057",
-    "r-b010262e30e9",
-    "s-3a10ebc70551"
+    "015e3b813a48e1a8",
+    "2bb428bc27c15476",
+    "6e8743481973e9a7",
+    "d6c7c6773fffc1a4",
+    "f20df2b382d07333",
+    "f94ed7b140562ea9"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17267,8 +17267,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-6fa594f32a8b": -1,
-       "o-dcd9a4ad02d9": 1
+       "c23a49f8a463e7d2": 1,
+       "f94ed7b140562ea9": -1
       }
      }
     },
@@ -17284,14 +17284,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-23c1b07d18db": 1,
-       "s-245868b85390": 1,
-       "s-39b3a1b3e499": 1,
-       "s-3a10ebc70551": -7,
-       "s-b9fe5a3f2082": 1,
-       "s-bbca9611666c": 1,
-       "s-cb2b1c7f44bb": 1,
-       "s-f23dfa018ac8": 1
+       "015e3b813a48e1a8": -7,
+       "1e9222aaf7fee4c8": 1,
+       "3d45438bc030e87d": 1,
+       "5311820b9a85f3f8": 1,
+       "6a4dc9c04931eb2c": 1,
+       "90c5912c91bd55ef": 1,
+       "e3d850c7714d7d2b": 1,
+       "f11c7d3ccd37ecf3": 1
       }
      }
     }
@@ -17305,10 +17305,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-684deac31fed",
-    "r-adefff38636c",
-    "s-595568e69baa",
-    "s-87e9485d2ab7"
+    "1a51d41befabeba5",
+    "7f6635da6029c200",
+    "9ce566ee26291a13",
+    "d325fd1dc2e65cef"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17336,14 +17336,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3c0eaf620489": 2,
-       "s-595568e69baa": -6,
-       "s-62b9807c3d57": 2,
-       "s-726978e3ea4d": 1,
-       "s-82e4d653597a": 2,
-       "s-87e9485d2ab7": -5,
-       "s-abb895fbfbb8": 2,
-       "s-ed74f28e357f": 2
+       "1a51d41befabeba5": -5,
+       "1afe33255a7b0b48": 2,
+       "2ad2e94610328c47": 2,
+       "4eaa8131a69ef71d": 2,
+       "6d3d219ce7cd6131": 2,
+       "7f6635da6029c200": -6,
+       "dc23046740b0f85f": 2,
+       "f2570015bb9e32b6": 1
       }
      }
     }
@@ -17357,11 +17357,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-47cbbb4fb209",
-    "s-27ac16e736ed",
-    "s-8188c7a828c4",
-    "s-9d94ac26b546",
-    "u-c6131e775fe4"
+    "0a5d22f99c0df623",
+    "4b064e58e7229998",
+    "895e2cd0edbcfb1f",
+    "8e29f196973654b3",
+    "9ea4d263f0135f6b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17393,13 +17393,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0e9ba98943ff": 2,
-       "s-1a5f8c6eee8b": 3,
-       "s-27ac16e736ed": -1,
-       "s-3653d2277143": 2,
-       "s-8188c7a828c4": -4,
-       "s-9d94ac26b546": -4,
-       "s-ad6cdb000f74": 2
+       "0a5d22f99c0df623": -4,
+       "4b064e58e7229998": -4,
+       "7a5d13f4a48a3162": 2,
+       "8d0b713fe9331c59": 2,
+       "9825c4278ea3045c": 3,
+       "9ea4d263f0135f6b": -1,
+       "e57cd71db82c8d6d": 2
       }
      }
     }
@@ -17413,15 +17413,15 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "r-1ed3d044fa90",
-    "r-5444e34f437c",
-    "r-b840c213a11a",
-    "s-03f452d0f87b",
-    "s-072187aa7f9d",
-    "s-523e27c1231a",
-    "s-bb4b9efbf020",
-    "s-bb7dfa28c1e8",
-    "s-f0611f17ae6e"
+    "032de277ace925c3",
+    "34f8201f167d9961",
+    "435cd2ea2fa01057",
+    "50133741bc5cc09d",
+    "643817e356f8877d",
+    "6d37af37f8edf833",
+    "9517df9ec44030ee",
+    "acbe45113a8d2ff0",
+    "f55e599f54dd7d2f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17455,23 +17455,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-03f452d0f87b": -4,
-       "s-049041be43ab": 5,
-       "s-072187aa7f9d": -10,
-       "s-192d1c93f1db": 3,
-       "s-278e2a1aec14": 6,
-       "s-523e27c1231a": -10,
-       "s-71e90fe5b5ee": 1,
-       "s-78b7bc561d53": 3,
-       "s-8cc8cd3128a2": 6,
-       "s-a4d142a848cc": 3,
-       "s-ae90bdf41a32": 3,
-       "s-b69cb2987e23": 4,
-       "s-bb4b9efbf020": -4,
-       "s-bb7dfa28c1e8": -10,
-       "s-c6990c83f8c2": 3,
-       "s-eb0b6c2f47db": 6,
-       "s-f0611f17ae6e": -5
+       "032de277ace925c3": -10,
+       "3f830553c1bd1e18": 6,
+       "4d4103e730b1dcea": 3,
+       "5db31420e4c587bb": 5,
+       "643817e356f8877d": -5,
+       "6d37af37f8edf833": -4,
+       "749004cb076ce351": 3,
+       "86e6a47ced0f10cd": 3,
+       "9517df9ec44030ee": -4,
+       "acbe45113a8d2ff0": -10,
+       "aeed58ad65496023": 3,
+       "b5f35ec49a726b78": 6,
+       "bbb865cf9cbc9833": 4,
+       "dea4d040d15da7e5": 3,
+       "e67af8bdb6490231": 1,
+       "f55e599f54dd7d2f": -10,
+       "fa342acd28b02624": 6
       }
      }
     }
@@ -17485,9 +17485,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-a325a0e291a5",
-    "s-39bb12b97973",
-    "s-78da2da41df9"
+    "2ccaec597cebb856",
+    "a877c378aec11f4b",
+    "fed71f27483d0dec"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17521,14 +17521,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-04ef6ab0c304": 2,
-       "s-39bb12b97973": -5,
-       "s-3e1594d98755": 2,
-       "s-4959156519f9": 2,
-       "s-5213c7a629fa": 1,
-       "s-6433c156ae35": 2,
-       "s-78da2da41df9": -5,
-       "s-f7f68860a0ae": 1
+       "082ffdc5ca86bd08": 1,
+       "4638dd0eba5611ec": 2,
+       "4f3f47ab851272ff": 1,
+       "4f59dc92b80fe80b": 2,
+       "8437667122b91c15": 2,
+       "a877c378aec11f4b": -5,
+       "f808c0e35f047cb9": 2,
+       "fed71f27483d0dec": -5
       }
      }
     }
@@ -17542,13 +17542,13 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-fc77db",
-    "s-c4b92d",
-    "s-e63dfb"
+    "33b50bc18aa3f95d",
+    "5e1f2795055806e5",
+    "b17eabf3025bc44e"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-fc77db"
+    "b17eabf3025bc44e"
    ],
    "over_budget": {
     "gated": true,
@@ -17571,10 +17571,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-3c8e30"
+       "0e899617f0e54768"
       ],
       "only_ungated": [
-       "s-c4b92d"
+       "33b50bc18aa3f95d"
       ]
      },
      "rank_diff": {
@@ -17582,10 +17582,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3c8e30": 2,
-       "s-8e76cd": 2,
-       "s-c4b92d": -2,
-       "s-e63dfb": -2
+       "0e899617f0e54768": 2,
+       "33b50bc18aa3f95d": -2,
+       "5e1f2795055806e5": -2,
+       "9d9104d3cb0fad49": 2
       }
      }
     }
@@ -17599,8 +17599,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-68cac233fb7d",
-    "s-8c81bb82ca15"
+    "476ed56303cc07e5",
+    "a92ca8643cb7bfde"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17628,9 +17628,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3f451d1a34cb": 2,
-       "s-68cac233fb7d": -1,
-       "s-8c81bb82ca15": -1
+       "0b607aa6d399abb0": 2,
+       "476ed56303cc07e5": -1,
+       "a92ca8643cb7bfde": -1
       }
      }
     }
@@ -17644,12 +17644,12 @@
    "n_flipped_items": 11,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "s-2f9d3fb1a1f0",
-    "s-58dbf97d280b",
-    "s-78c22beb1d6d",
-    "s-9f733308a38d",
-    "s-af7be76512ae",
-    "s-d69308241044"
+    "485016306773d478",
+    "66b1252b6142c8f3",
+    "75abe206e235ae74",
+    "b27d53532ac661de",
+    "c476f2d7d10706e2",
+    "fb3f0c114ca16227"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17683,20 +17683,20 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-09d5269fed2a": 4,
-       "s-0efa47fca1f0": 2,
-       "s-2f9d3fb1a1f0": -5,
-       "s-488e5a04a0ba": 5,
-       "s-58dbf97d280b": -5,
-       "s-6e6dba92b227": 3,
-       "s-78c22beb1d6d": -4,
-       "s-8048d39ec9bb": 5,
-       "s-94a4e48b5eba": 1,
-       "s-9f733308a38d": -3,
-       "s-af7be76512ae": -5,
-       "s-bc9f593bef9e": 5,
-       "s-bed520699891": 2,
-       "s-d69308241044": -5
+       "033c44c5893a1854": 3,
+       "485016306773d478": -5,
+       "4e887036130c484a": 4,
+       "66b1252b6142c8f3": -3,
+       "75abe206e235ae74": -4,
+       "841882088f1e4639": 5,
+       "948115220a835aa9": 2,
+       "a594abec94c55479": 1,
+       "b27d53532ac661de": -5,
+       "c476f2d7d10706e2": -5,
+       "d27ea4c345afb55b": 5,
+       "da1e3a7200b6f042": 5,
+       "efb60641cb0013bb": 2,
+       "fb3f0c114ca16227": -5
       }
      }
     }
@@ -17710,11 +17710,11 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-05d5cc118883",
-    "r-80b226337f04",
-    "s-3ad2e68c81e0",
-    "s-4fb7063ee795",
-    "s-85ad2f367e5b"
+    "3397618326dcb8af",
+    "3421dcf2721cfa32",
+    "457413edf73c971d",
+    "8d5ecf8c083bb864",
+    "e5bafed9f0c72347"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17746,12 +17746,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3ad2e68c81e0": -1,
-       "s-3ee6cbe0cf39": 1,
-       "s-4fb7063ee795": -3,
-       "s-85ad2f367e5b": -1,
-       "s-8967aa99c960": 3,
-       "s-c990525d81c4": 1
+       "06629b06c4d6262c": 1,
+       "3397618326dcb8af": -3,
+       "3421dcf2721cfa32": -1,
+       "457413edf73c971d": -1,
+       "70565553c3bc1009": 1,
+       "f4209f973a7c9db4": 3
       }
      }
     }
@@ -17765,10 +17765,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-805c50edbf58",
-    "s-1c0c846d50d9",
-    "s-7538b336f3dc",
-    "s-b9c0357f3e96"
+    "58a42235529e4494",
+    "ee3e6e533cf0e93d",
+    "f1d97a3acd95f74f",
+    "f856cecd56821f35"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17802,20 +17802,20 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1c0c846d50d9": -3,
-       "s-1f7a55c1ce8e": 1,
-       "s-5275e14733ac": 1,
-       "s-7538b336f3dc": -3,
-       "s-8d685778a6f2": 1,
-       "s-92f20934fb36": 1,
-       "s-99e55152ecd6": 2,
-       "s-ae52135cd60d": 1,
-       "s-ae97eeb988f7": 3,
-       "s-b951f9a003c7": 1,
-       "s-b9c0357f3e96": -9,
-       "s-bf12fbf55e24": 1,
-       "s-cc1d0741882b": 2,
-       "s-eadfe889ac68": 1
+       "1ccd8067d959eacc": 1,
+       "2de8a717c7a51b83": 2,
+       "310d34372b6aa137": 1,
+       "636b47eaddad8341": 1,
+       "652acb71f0cb392d": 1,
+       "676e5a8de0bb68f4": 1,
+       "7957e89b23972522": 3,
+       "9a7d66e37e3b807b": 1,
+       "9fb8ebb89b8d8a99": 1,
+       "a9a9f85bf35a29fc": 2,
+       "b027560170f8d19a": 1,
+       "ee3e6e533cf0e93d": -9,
+       "f1d97a3acd95f74f": -3,
+       "f856cecd56821f35": -3
       }
      }
     }
@@ -17829,23 +17829,23 @@
    "n_flipped_items": 19,
    "n_lid_biting_flips": 17,
    "lid_biting_items": [
-    "h:99e42dfe2938",
-    "r-0f1d56e656b7",
-    "r-2009748f4cdb",
-    "r-6ad17412b0be",
-    "r-9731ddc4f174",
-    "r-9867c097bf4d",
-    "r-a3eaa03cf828",
-    "r-c044d7edb5f0",
-    "r-e69bc19bd0e6",
-    "s-04dece143d52",
-    "s-28643d000f9a",
-    "s-35697cf0a7b2",
-    "s-55cedf866b6f",
-    "s-730748221d37",
-    "s-8819f107781a",
-    "s-b6c81807b5e7",
-    "s-bafaa6b06351"
+    "0ba483b9f2bef654",
+    "106483b9bbab5f52",
+    "27b582d792e30b3c",
+    "3ccbc75a3a13a7b9",
+    "452efa74a232ac7b",
+    "499601545b6f9800",
+    "7638e5cbbf30b49a",
+    "7cccfc984bee80a0",
+    "8c29714a744cdc28",
+    "95a6caf4d193ef6d",
+    "b68850760f8ebf05",
+    "b8f4ff2a60a17fec",
+    "c4b262330d9d1c52",
+    "ca3ab71d3c3e95e5",
+    "dd36e028404adce1",
+    "eff6a936f00fba64",
+    "f92428e917a274db"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17881,26 +17881,26 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-020468f1dfeb": 7,
-       "s-0225b0e6e55b": 4,
-       "s-04dece143d52": -5,
-       "s-216e1695c671": 5,
-       "s-28643d000f9a": -8,
-       "s-335347ed6e2b": 1,
-       "s-35697cf0a7b2": -3,
-       "s-375fc7c30a01": 3,
-       "s-55cedf866b6f": -5,
-       "s-652ea2ccda71": 4,
-       "s-730748221d37": -9,
-       "s-7969f3ade184": 3,
-       "s-861bb07a6014": 4,
-       "s-8819f107781a": -9,
-       "s-ad36fc031bb5": 7,
-       "s-b6c81807b5e7": -5,
-       "s-bac5f45c7579": 7,
-       "s-bafaa6b06351": -9,
-       "s-d4c29ad5eea3": 4,
-       "s-eda44702896b": 4
+       "035a58eb8d6750be": 4,
+       "106483b9bbab5f52": -8,
+       "27b582d792e30b3c": -5,
+       "2a0b8bc85ec92a4d": 4,
+       "39466bee7d61f9de": 1,
+       "396df1d9b152dee0": 3,
+       "39708e1aacdcf968": 4,
+       "452efa74a232ac7b": -3,
+       "7b2ba2134e97e665": 7,
+       "7b3fb8be79306dad": 7,
+       "7cccfc984bee80a0": -5,
+       "8c29714a744cdc28": -9,
+       "992e040b9e99dda3": 3,
+       "aeece569386179d2": 5,
+       "b2c472bc75dd8185": 7,
+       "b8f4ff2a60a17fec": -5,
+       "dd36e028404adce1": -9,
+       "f92428e917a274db": -9,
+       "fc7d4ab7f2a16d4a": 4,
+       "fe3408a427b71ab5": 4
       }
      }
     }
@@ -17914,11 +17914,11 @@
    "n_flipped_items": 5,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-23dd02",
-    "r-ae0645",
-    "s-908958",
-    "s-d3a45d",
-    "u-26f92e"
+    "4c2b6b0c9242f365",
+    "a2cfc58874b1d480",
+    "bcb591a2a8b21206",
+    "d60febb1bc9cf750",
+    "df5c54c00a5b16b6"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -17946,8 +17946,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2738c4": 1,
-       "s-d3a45d": -1
+       "4c2b6b0c9242f365": -1,
+       "bee14eeff7bfebe3": 1
       }
      }
     },
@@ -17963,8 +17963,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-26f92e": -1,
-       "u-9c3f68": 1
+       "df5c54c00a5b16b6": -1,
+       "fc369bf173e3422c": 1
       }
      }
     }
@@ -17978,8 +17978,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-12db08ce4e8a",
-    "s-58e65c1c4cb5"
+    "251126300c4c7f85",
+    "90f06d82287ba48d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18011,11 +18011,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-58e65c1c4cb5": -4,
-       "s-6c3cfb4336ae": 1,
-       "s-b0e5fe1700d0": 1,
-       "s-bd98eeb60865": 1,
-       "s-c36d3498f9a0": 1
+       "0804011bb1b6cd59": 1,
+       "5c3dacea54238e03": 1,
+       "90f06d82287ba48d": -4,
+       "e9685179dc7637bc": 1,
+       "f13d4e0a92c64680": 1
       }
      }
     }
@@ -18029,14 +18029,14 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-0aa2bcc34d85",
-    "r-71302d91e245",
-    "r-8fd56d44e05a",
-    "r-b1cc2df0ce2f",
-    "s-8ca9ac975e1b",
-    "s-9b3aab1491f1",
-    "s-a39eccfea9c3",
-    "s-faaf96b10cb9"
+    "1716032554a616bd",
+    "2a2dc64f065392fa",
+    "34312579afbcbb6a",
+    "4adccb4284872704",
+    "9a3772a1a1d4736a",
+    "af1766cdf755a7b6",
+    "cda7a98c8f21ba0a",
+    "fa56dee55d33a30d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18061,12 +18061,12 @@
      "cap_crossings": {
       "count": 4,
       "only_gated": [
-       "s-56546a4e0ab3",
-       "s-921c1bc4c032"
+       "1d226cc05facdbfd",
+       "4b8061fc359235a7"
       ],
       "only_ungated": [
-       "s-8ca9ac975e1b",
-       "s-9b3aab1491f1"
+       "2a2dc64f065392fa",
+       "fa56dee55d33a30d"
       ]
      },
      "rank_diff": {
@@ -18074,16 +18074,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-22a4ccca0c9c": 4,
-       "s-56546a4e0ab3": 4,
-       "s-60dd9edb58ff": 4,
-       "s-8ca9ac975e1b": -6,
-       "s-921c1bc4c032": 3,
-       "s-9b3aab1491f1": -4,
-       "s-a39eccfea9c3": -4,
-       "s-a5374aec50f1": 1,
-       "s-b13e3a6cefd8": 1,
-       "s-faaf96b10cb9": -3
+       "1716032554a616bd": -3,
+       "1d226cc05facdbfd": 4,
+       "2a2dc64f065392fa": -6,
+       "4b8061fc359235a7": 3,
+       "8fce7dcdfacafbfb": 4,
+       "97702c538fe6e70b": 1,
+       "a0883d1e6b957db8": 4,
+       "cda7a98c8f21ba0a": -4,
+       "da1177c7e691011f": 1,
+       "fa56dee55d33a30d": -4
       }
      }
     }
@@ -18097,20 +18097,20 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 14,
    "lid_biting_items": [
-    "o-3197fa",
-    "o-c7c3d5",
-    "o-ffc7af",
-    "r-2580a5",
-    "r-2c5793",
-    "r-4dca60",
-    "r-5b79a5",
-    "r-d6d8c2",
-    "r-eb1e1a",
-    "r-f0130f",
-    "s-26326d",
-    "s-54da91",
-    "s-817383",
-    "u-1876cc"
+    "0c7c51ff542fcaf8",
+    "1c6f7e13a2fedd8d",
+    "2af5f749fd163eb5",
+    "33c2005a4cdcdb31",
+    "3b330bca624ee20a",
+    "4037f23a372fbe11",
+    "7255ee27418439d9",
+    "9d4d45011ad4d746",
+    "a3314f6b0cf38fc2",
+    "d5e27b65cbf8bc5d",
+    "d67e59117013c51b",
+    "e2fb50da70a69651",
+    "e80067dc6973c507",
+    "fe538cbf346fa36a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18142,12 +18142,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-3197fa": -4,
-       "o-60c766": 2,
-       "o-65c4e3": 2,
-       "o-6ccd26": 2,
-       "o-bb142d": 2,
-       "o-ffc7af": -4
+       "4bbbc0dd2dfe02e5": 2,
+       "6107e5787d22c387": 2,
+       "6ad0f908fcae6301": 2,
+       "6d558ac422a46708": 2,
+       "7255ee27418439d9": -4,
+       "a3314f6b0cf38fc2": -4
       }
      }
     },
@@ -18163,13 +18163,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-4b01ff": 1,
-       "o-548468": 1,
-       "o-5762e8": 1,
-       "o-8c0397": 1,
-       "o-b74444": 1,
-       "o-c7c3d5": -6,
-       "o-e3c230": 1
+       "20d6b8a75cc406ef": 1,
+       "4c7e695db7fee59e": 1,
+       "50ce20db42050ba3": 1,
+       "8ef00ccd621a362e": 1,
+       "a38de4262835c5be": 1,
+       "e3e8ac2cb85c906a": 1,
+       "e80067dc6973c507": -6
       }
      }
     },
@@ -18178,13 +18178,13 @@
      "cap_crossings": {
       "count": 5,
       "only_gated": [
-       "s-8a523d",
-       "s-c9115d",
-       "s-e0a40e",
-       "s-f7eeef"
+       "6abfd106c7ade4f8",
+       "70afd33d1e53ec36",
+       "73c89c2f07924f82",
+       "87401314ef3a555e"
       ],
       "only_ungated": [
-       "s-26326d"
+       "4037f23a372fbe11"
       ]
      },
      "rank_diff": {
@@ -18192,15 +18192,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-26326d": -6,
-       "s-4aa62a": 3,
-       "s-54da91": -5,
-       "s-817383": -6,
-       "s-8a523d": 3,
-       "s-957823": 3,
-       "s-c9115d": 3,
-       "s-e0a40e": 3,
-       "s-f7eeef": 2
+       "2af5f749fd163eb5": -6,
+       "33c2005a4cdcdb31": -5,
+       "39df3ff805808f6b": 3,
+       "4037f23a372fbe11": -6,
+       "6abfd106c7ade4f8": 3,
+       "70afd33d1e53ec36": 3,
+       "73c89c2f07924f82": 3,
+       "87401314ef3a555e": 2,
+       "f086e46cf84c73d0": 3
       }
      }
     },
@@ -18216,10 +18216,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-1876cc": -3,
-       "u-d1b3ec": 1,
-       "u-df22f3": 1,
-       "u-f83ec1": 1
+       "4018ffa8fd74b367": 1,
+       "79833b2ec65139fc": 1,
+       "d5b83277c3359d0a": 1,
+       "fe538cbf346fa36a": -3
       }
      }
     }
@@ -18233,9 +18233,9 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-3197fa",
-    "o-c7c3d5",
-    "o-ffc7af"
+    "7255ee27418439d9",
+    "a3314f6b0cf38fc2",
+    "e80067dc6973c507"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18267,11 +18267,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-3197fa": -3,
-       "o-60c766": 2,
-       "o-65c4e3": 2,
-       "o-bb142d": 2,
-       "o-ffc7af": -3
+       "6107e5787d22c387": 2,
+       "6ad0f908fcae6301": 2,
+       "6d558ac422a46708": 2,
+       "7255ee27418439d9": -3,
+       "a3314f6b0cf38fc2": -3
       }
      }
     }
@@ -18285,12 +18285,12 @@
    "n_flipped_items": 7,
    "n_lid_biting_flips": 6,
    "lid_biting_items": [
-    "r-0afc9629dbd7",
-    "r-7f8d857d0e8b",
-    "r-b0ce28c410c7",
-    "r-f6fdf7371ef2",
-    "r-fa1cc5b2787b",
-    "s-bce03542f86e"
+    "10686871fec7e287",
+    "3ee08bd204bd1b83",
+    "4739dff9e7b1896f",
+    "68f87be5a9ba03d6",
+    "7bb9d9469ef76ee5",
+    "af27289a2eedc622"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18322,8 +18322,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-101815e3ade6": 1,
-       "s-bce03542f86e": -1
+       "3ee08bd204bd1b83": -1,
+       "c1f77c18ff68eae1": 1
       }
      }
     }
@@ -18337,8 +18337,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-4ad52585a6f0",
-    "s-cc5dd42bb1b0"
+    "21b96d106232b92c",
+    "e762b4f03a1cc96b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18372,15 +18372,15 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1350014be3b7": 2,
-       "s-4ad52585a6f0": -6,
-       "s-8497e6618288": 2,
-       "s-a569e29db964": 2,
-       "s-cc5dd42bb1b0": -7,
-       "s-e051fda167ce": 1,
-       "s-e562309585e7": 2,
-       "s-f1d57189e8c3": 2,
-       "s-f3738d0076eb": 2
+       "21b96d106232b92c": -6,
+       "3f71d8762f0a0538": 2,
+       "61f38e7579a0202b": 2,
+       "68025663edcf2e56": 2,
+       "8d4ab7c2d92fa3c2": 1,
+       "9a577661af2024ee": 2,
+       "b94a7ed479c6e660": 2,
+       "c631007b1e78f0e5": 2,
+       "e762b4f03a1cc96b": -7
       }
      }
     }
@@ -18394,9 +18394,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "h:71680316bdb6",
-    "r-b474e2151408",
-    "s-3a94c506987c"
+    "4f0990c9d9774ea6",
+    "81269ace5fb10ef8",
+    "c448f61190a5e85d"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18424,8 +18424,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-3a94c506987c": -1,
-       "s-a91c3b98c508": 1
+       "81269ace5fb10ef8": -1,
+       "9f6d9827045e52ac": 1
       }
      }
     }
@@ -18439,10 +18439,10 @@
    "n_flipped_items": 6,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "h:b7970c54cbdc",
-    "r-01a65cdd04b0",
-    "s-0b3c73f00ffa",
-    "s-2f10cede81ed"
+    "4cf533e5e8805c44",
+    "695033ef55435486",
+    "be348454d213b343",
+    "fee433c6748704ec"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18470,14 +18470,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0b3c73f00ffa": -3,
-       "s-2f10cede81ed": -6,
-       "s-48f0c30e7ecf": 2,
-       "s-5a6872c689fe": 1,
-       "s-5d5c7dcb308a": 1,
-       "s-5f34f3e1fc67": 2,
-       "s-cec4e9181fcf": 1,
-       "s-e0f8a632b795": 2
+       "40f530d8d0ce544b": 2,
+       "695033ef55435486": -3,
+       "7d9e814e168220b3": 2,
+       "f4ac7b3c745daddb": 1,
+       "f76c5d06927db8d8": 2,
+       "fa4afdf9545cc9ef": 1,
+       "fd97aab1215b6e8b": 1,
+       "fee433c6748704ec": -6
       }
      }
     }
@@ -18491,9 +18491,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-782e80",
-    "r-84d346",
-    "u-58ea51"
+    "3d1cdda1a70129d3",
+    "c65e46b3109f6315",
+    "c8409f0850b65938"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18525,12 +18525,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-253f49": 1,
-       "u-4a151b": 1,
-       "u-58ea51": -5,
-       "u-5ca1f0": 1,
-       "u-8fad4a": 1,
-       "u-fd0e74": 1
+       "3d1cdda1a70129d3": -5,
+       "68efadd2139e9bc7": 1,
+       "81c6154f91fbe81c": 1,
+       "b7917cdc1e8894e2": 1,
+       "c9ea7ccdd4f2b720": 1,
+       "f79a4a63427789cd": 1
       }
      }
     }
@@ -18544,15 +18544,15 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "h:420d8b0d3232",
-    "r-0a3c1301b674",
-    "r-3f298fc9fd56",
-    "r-8ec210bb1db6",
-    "r-a6390f161975",
-    "r-b3ec7737467d",
-    "r-bd05fb69f4c7",
-    "r-e9ed56d65e45",
-    "s-e6b5acd7f1b6"
+    "1e65a30a22a46925",
+    "3a5a28e2a1d96a21",
+    "606c0d55d4efd49a",
+    "7bd22252d73f67ac",
+    "8bbaa08a5846c44b",
+    "b6f693bc11ea3bb3",
+    "d06a8c696fae89ff",
+    "dad2cdf15e71eb9d",
+    "ded48e7a39f8c8ef"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18586,10 +18586,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-46e77aac1a8c": 1,
-       "s-6236e67e72f9": 1,
-       "s-d381d9ff15d1": 1,
-       "s-e6b5acd7f1b6": -3
+       "4f3ec85093f00c47": 1,
+       "828e90ce532326b9": 1,
+       "8d9135be2a598ed6": 1,
+       "dad2cdf15e71eb9d": -3
       }
      }
     }
@@ -18603,18 +18603,18 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 8,
    "lid_biting_items": [
-    "r-30751d",
-    "r-8cc053",
-    "r-b2f453",
-    "s-57fca2",
-    "s-80dcc0",
-    "s-c79a2e",
-    "u-6d75e8",
-    "u-7d7a5e"
+    "246e34c42e2348f6",
+    "67525817b1e01d57",
+    "7b216ee919bc4092",
+    "a9657266e0abec47",
+    "aa1f7f7f35ecdb19",
+    "d15a14e46630f0e0",
+    "d9db42533879681c",
+    "e5c6b058d1747ed5"
    ],
    "n_truncation_exempting_flips": 1,
    "truncation_exempting_items": [
-    "r-30751d"
+    "e5c6b058d1747ed5"
    ],
    "over_budget": {
     "gated": true,
@@ -18644,13 +18644,13 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-57fca2": -3,
-       "s-80dcc0": -2,
-       "s-817892": 2,
-       "s-8cbc53": 2,
-       "s-c79a2e": -3,
-       "s-cc165d": 1,
-       "s-feca74": 3
+       "246e34c42e2348f6": -3,
+       "67525817b1e01d57": -2,
+       "76fc0a62b42aefce": 1,
+       "7b216ee919bc4092": -3,
+       "98fa49abadd96a04": 3,
+       "a75bf09078abbc44": 2,
+       "a8408910422843e9": 2
       }
      }
     },
@@ -18666,9 +18666,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-167e68": 2,
-       "u-6d75e8": -1,
-       "u-7d7a5e": -1
+       "a5889837bf154200": 2,
+       "a9657266e0abec47": -1,
+       "aa1f7f7f35ecdb19": -1
       }
      }
     }
@@ -18682,8 +18682,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-86bddfcc3b3b",
-    "u-0ece300f80f5"
+    "778de2647e2d5218",
+    "7b02f3f617452c7c"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18717,10 +18717,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1638463ff19e": 1,
-       "s-86bddfcc3b3b": -3,
-       "s-9f1023113877": 1,
-       "s-cc29b609b2a4": 1
+       "164fc9c666d6400d": 1,
+       "6fd94aef252b9fd1": 1,
+       "778de2647e2d5218": -3,
+       "c5a74bc362286e7e": 1
       }
      }
     },
@@ -18736,8 +18736,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-0ece300f80f5": -1,
-       "u-76051102e542": 1
+       "7b02f3f617452c7c": -1,
+       "dfb34e3ab62986af": 1
       }
      }
     }
@@ -18751,11 +18751,11 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-347acc9ba2c1",
-    "r-36ba636d8141",
-    "r-8b534d7e9fb7",
-    "s-3c0ca4653cdb",
-    "s-97ea9edbf5fd"
+    "06f2b37fdcf24c4e",
+    "28e54e1171a5ebca",
+    "8aa69fb291a447b8",
+    "c2cd8d653641b8dc",
+    "c893fad7043a4743"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18789,23 +18789,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-01865d51b0bd": 2,
-       "s-1b361ad651e4": 2,
-       "s-28b19a7f512e": 1,
-       "s-3c0ca4653cdb": -9,
-       "s-55f9752cbd54": 2,
-       "s-5a4196ab726d": 1,
-       "s-5d00da966a72": 2,
-       "s-6241930d9d76": 1,
-       "s-7b2f567591ee": 1,
-       "s-8b3ffce8d021": 2,
-       "s-97ea9edbf5fd": -14,
-       "s-b3092086f728": 1,
-       "s-d01dabdbc8f4": 2,
-       "s-d293f9d62643": 1,
-       "s-e2e46ac0f8a3": 1,
-       "s-ef933a11e4e9": 2,
-       "s-faceac53fc70": 2
+       "06fcbf62c24ac7c3": 1,
+       "08f1b6884e2e7953": 1,
+       "140ee3ccda964c4e": 2,
+       "28e54e1171a5ebca": -14,
+       "390f121130a91e4b": 2,
+       "413fd1472520f316": 2,
+       "4686d89be43e2a8f": 2,
+       "4e04614ec85c8ffb": 1,
+       "54ff0ee8a14a680a": 2,
+       "591cb81837541d47": 1,
+       "5bb35b24379d3e7d": 1,
+       "835d97a67b76608b": 2,
+       "8779f15dd2cc78ad": 1,
+       "8aa69fb291a447b8": -9,
+       "a33093780053b235": 2,
+       "f2f5cb150f9e4e81": 1,
+       "f91b69c08f097347": 2
       }
      }
     }
@@ -18819,20 +18819,20 @@
    "n_flipped_items": 15,
    "n_lid_biting_flips": 14,
    "lid_biting_items": [
-    "r-00f22dec9d1f",
-    "r-21b993a16d7d",
-    "r-22be0d8b7827",
-    "r-60f86def3484",
-    "r-a57b8f7f4e81",
-    "r-b94cdedb9510",
-    "r-d60cc56a499c",
-    "r-f87e128d3cf0",
-    "r-f8fb625c7854",
-    "s-284ce5de5944",
-    "s-37133b7f1935",
-    "s-6cfd5c1e5615",
-    "s-e9efc50fb461",
-    "s-fab7035d0efa"
+    "0f5319af3d65e1cf",
+    "13ffe521b63bcfb4",
+    "16c73c66d0bb5ad2",
+    "3c41ab761fb4c887",
+    "4ea19de146ffbde9",
+    "5e5559d86edf4146",
+    "741f3af81ef56fa9",
+    "877be6efd7c0fe8d",
+    "913b54e81ecebf6c",
+    "974dd3d2563c48fb",
+    "b217907fb9d3a886",
+    "d9758431dff03e41",
+    "f166feebc3d71053",
+    "fc51987c6b354714"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18866,23 +18866,23 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0d216333f524": 2,
-       "s-11d224e0fe2b": 5,
-       "s-2116044bf38d": 1,
-       "s-284ce5de5944": -4,
-       "s-37133b7f1935": -7,
-       "s-47b102970a80": 4,
-       "s-5dc0f024d0f2": 2,
-       "s-6cfd5c1e5615": -10,
-       "s-7208295a3cb1": 3,
-       "s-8631d47a8e06": 4,
-       "s-8f8c889d93e2": 4,
-       "s-cb064b447c48": 2,
-       "s-d1212adf8f1e": 1,
-       "s-d24b3cdd2b9b": 5,
-       "s-d7af6c3128d5": 1,
-       "s-e9efc50fb461": -7,
-       "s-fab7035d0efa": -6
+       "02ddc279f8ac6230": 4,
+       "145b7cf6db1d2dc8": 2,
+       "1cd57fecaec94e09": 1,
+       "341742f9dd470e2c": 5,
+       "3c41ab761fb4c887": -4,
+       "3e69d74f24593d81": 1,
+       "4bc3eda0ecb1eca6": 5,
+       "5e5559d86edf4146": -10,
+       "741f3af81ef56fa9": -7,
+       "835d0581921373fb": 3,
+       "8ab87072db07c57f": 4,
+       "974dd3d2563c48fb": -6,
+       "c77a1e82f7dda429": 4,
+       "cfd09c2f46e074a0": 2,
+       "d17130323dbb1d11": 1,
+       "d252556ec8089c90": 2,
+       "f166feebc3d71053": -7
       }
      }
     }
@@ -18896,15 +18896,15 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 9,
    "lid_biting_items": [
-    "r-00036980ecd3",
-    "r-08f3a9683ad7",
-    "r-198247b1e2d1",
-    "r-58d79aa5b5ea",
-    "r-868d3eff115e",
-    "r-adda21c8dffd",
-    "r-fdf5c0d1a81c",
-    "s-24b4c614ebb7",
-    "s-87268b3bf912"
+    "127ff6b5f3c222cc",
+    "4c24c2e6339aa7e4",
+    "613e51b810fdb766",
+    "68d1a9f063072815",
+    "71b9292e9edb03c1",
+    "bcbcbf0b90434d0e",
+    "cd4e31cf7e63ad87",
+    "d65cae10a5e12667",
+    "f7dacee927e33384"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -18929,10 +18929,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-c0b0cd074e91"
+       "9d478509c36bc660"
       ],
       "only_ungated": [
-       "s-87268b3bf912"
+       "d65cae10a5e12667"
       ]
      },
      "rank_diff": {
@@ -18940,24 +18940,24 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-0a3dc2b4bd49": 1,
-       "s-24b4c614ebb7": -4,
-       "s-25d5562ca9d6": 1,
-       "s-462780af0a06": 1,
-       "s-5c71b1e557f3": 1,
-       "s-62a9206a2a05": 1,
-       "s-6e0986084e5e": 1,
-       "s-6fcbf98a4092": 1,
-       "s-70705d77e389": 1,
-       "s-8127dfcc5940": 1,
-       "s-87268b3bf912": -12,
-       "s-8f7197e9e7dd": 1,
-       "s-961044e4780e": 1,
-       "s-970b0e7b01b5": 1,
-       "s-c0b0cd074e91": 1,
-       "s-f3d7c857ec31": 1,
-       "s-f69f4489004d": 1,
-       "s-f899e1f38491": 1
+       "0296f7b6fcb60a82": 1,
+       "20ff314fb45a50ce": 1,
+       "2d7acb1a3a1c7363": 1,
+       "3a62c2f0af732656": 1,
+       "4355ddaba76a4150": 1,
+       "5ba7dd6344db1a0a": 1,
+       "613e51b810fdb766": -4,
+       "694bb0bde93eb6cd": 1,
+       "8314c9b398ee04c0": 1,
+       "8788c64ef9bbea44": 1,
+       "8a0f034c20759b6c": 1,
+       "9ba981acea795537": 1,
+       "9d478509c36bc660": 1,
+       "c834cbecdcaa33ca": 1,
+       "d65cae10a5e12667": -12,
+       "ebf65045fb554467": 1,
+       "ef85844ba51b86b6": 1,
+       "fb808f084ecb3021": 1
       }
      }
     }
@@ -18971,18 +18971,18 @@
    "n_flipped_items": 14,
    "n_lid_biting_flips": 12,
    "lid_biting_items": [
-    "h:80fa5bae16f1",
-    "o-7cdc1b44faed",
-    "o-f0fa64daa1d0",
-    "r-1c8e507c8389",
-    "r-5f6b36ed6472",
-    "r-68ff24b84375",
-    "r-86d1014bebab",
-    "r-9bfb0988eea2",
-    "s-2a676bf74a48",
-    "s-c0823fa7911c",
-    "s-e26ea9ccd9a4",
-    "s-e81314aaa230"
+    "1e2135e78a8f84ac",
+    "1e70b22ecbb2a116",
+    "289aadcf3b4a9086",
+    "2afcbaba561bc314",
+    "47ad9d151abec12c",
+    "4d71a326f2e8090d",
+    "530ec7247a106696",
+    "5dd3a52c65b6e591",
+    "66e58663f6ecaf09",
+    "703c805528af3c7c",
+    "b67dde0ecd4b5725",
+    "ddd29c0ef7934076"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19014,18 +19014,18 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1d441ba9a653": 4,
-       "s-2a676bf74a48": -8,
-       "s-30dfcd70ac05": 4,
-       "s-699c5c0e711f": 1,
-       "s-800844412855": 4,
-       "s-b94890f108f2": 4,
-       "s-c0823fa7911c": -7,
-       "s-c65d1c3abfe9": 4,
-       "s-e26ea9ccd9a4": -7,
-       "s-e5d40ad3a74c": 4,
-       "s-e81314aaa230": -7,
-       "s-ed3a7f138930": 4
+       "289aadcf3b4a9086": -7,
+       "3034d7f9edb36cd0": 4,
+       "312a775b99da9e5f": 4,
+       "4d71a326f2e8090d": -7,
+       "530e85c3b97017e7": 4,
+       "614840617f225b3f": 4,
+       "6657ca2f222a14aa": 1,
+       "703c805528af3c7c": -8,
+       "7cdbbc6a81423fe6": 4,
+       "8a7998352e1d2d5e": 4,
+       "96a30459eed17b04": 4,
+       "b67dde0ecd4b5725": -7
       }
      }
     }
@@ -19039,7 +19039,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-011bcba81af5"
+    "ba8a7a3c35047766"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19067,8 +19067,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-011bcba81af5": -1,
-       "o-55fba15a1ce4": 1
+       "ba8a7a3c35047766": -1,
+       "c9e69501791d2c22": 1
       }
      }
     }
@@ -19082,8 +19082,8 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-cd0c8950dc84",
-    "s-ed1cc815927c"
+    "09086e2b06b980b9",
+    "565b7a81d2401246"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19111,8 +19111,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-4e26d42f9eb7": 1,
-       "s-ed1cc815927c": -1
+       "565b7a81d2401246": -1,
+       "c443376de39cf7cd": 1
       }
      }
     }
@@ -19126,9 +19126,9 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-584f87a6e6ff",
-    "r-76437c462918",
-    "s-83e89144cb27"
+    "1c6d2bf7ecc53ae3",
+    "4d162194f9faacb7",
+    "79f3f1385a3ad475"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19162,11 +19162,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-535c522dd09b": 1,
-       "s-699ae47ec3ee": 1,
-       "s-83e89144cb27": -4,
-       "s-f35978b781b0": 1,
-       "s-f6de5ed82b34": 1
+       "1c6d2bf7ecc53ae3": -4,
+       "51d91a8ea9f3fa85": 1,
+       "64f61e92d0fbaf54": 1,
+       "7130f5eec4a9b1ed": 1,
+       "9072ecc95365671e": 1
       }
      }
     }
@@ -19180,11 +19180,11 @@
    "n_flipped_items": 10,
    "n_lid_biting_flips": 5,
    "lid_biting_items": [
-    "r-38a0bb3be0f1",
-    "r-9a7d98cae503",
-    "s-092216a692db",
-    "s-4630b8adac76",
-    "s-79b0a318fd82"
+    "1fe489dc68e56070",
+    "7b1be34876862205",
+    "9719f6d091d8938e",
+    "9fba86b13abdbff7",
+    "f0176004367b80a7"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19216,14 +19216,14 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-092216a692db": -3,
-       "s-1709fc2250c8": 1,
-       "s-4630b8adac76": -2,
-       "s-56fee8dcaf96": 3,
-       "s-79b0a318fd82": -4,
-       "s-c40daa50e69c": 3,
-       "s-cbfd41611a09": 1,
-       "s-f35978b781b0": 1
+       "25ac751413f289bc": 1,
+       "456d8a89e00f7aa9": 3,
+       "51d91a8ea9f3fa85": 1,
+       "7b1be34876862205": -3,
+       "7b2719754e5cc740": 1,
+       "9719f6d091d8938e": -2,
+       "9fba86b13abdbff7": -4,
+       "e511035d0b333b33": 3
       }
      }
     }
@@ -19237,8 +19237,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-13150c437ced",
-    "s-235a1ab1239e"
+    "74590d5ef80cc47f",
+    "cceeb499f59b1553"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19272,10 +19272,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-16b50ec80dd9": 1,
-       "s-235a1ab1239e": -3,
-       "s-3f35d6899ea3": 1,
-       "s-ebfa82f0ac8e": 1
+       "054da6bfe4a91dea": 1,
+       "23501a415e4a27b3": 1,
+       "568816387ba09ba6": 1,
+       "cceeb499f59b1553": -3
       }
      }
     }
@@ -19289,7 +19289,7 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-77402a5543a1"
+    "ed9ec91e2c8eae8f"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19321,8 +19321,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-2b0bb850e756": 1,
-       "s-77402a5543a1": -1
+       "6ba435a56ff21d59": 1,
+       "ed9ec91e2c8eae8f": -1
       }
      }
     }
@@ -19336,9 +19336,9 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-eeec0855ad2a",
-    "r-1bba44fdb031",
-    "s-0f57fc500139"
+    "0a329e9dc2b9ba75",
+    "6b32dfa40705d70f",
+    "d6f7d77310af157b"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19370,8 +19370,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-de465008ef25": 1,
-       "o-eeec0855ad2a": -1
+       "6b32dfa40705d70f": -1,
+       "dcfca256634f4975": 1
       }
      }
     }
@@ -19385,10 +19385,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-9c33b310ea88",
-    "r-ff3d5f2de1cd",
-    "s-bafea4bc8b6a",
-    "s-be240783231b"
+    "0f19b9710151ee8f",
+    "2ddac2de0f790560",
+    "baf8e5c89f1761f0",
+    "e5e20acaee4d1ba0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19420,9 +19420,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-bafea4bc8b6a": -1,
-       "s-be240783231b": -1,
-       "s-f3af909f9c3e": 2
+       "0f19b9710151ee8f": -1,
+       "199c9e9beae3c9b5": 2,
+       "e5e20acaee4d1ba0": -1
       }
      }
     }
@@ -19436,8 +19436,8 @@
    "n_flipped_items": 3,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-8253a0bb1f8f",
-    "s-f537d54ba671"
+    "227456aa684846ef",
+    "fec53ef1f739c6ff"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19465,12 +19465,12 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-13420dc0a7f9": 1,
-       "s-693429a3250b": 1,
-       "s-8b48aba65dce": 1,
-       "s-8e3bac6369a5": 1,
-       "s-f537d54ba671": -5,
-       "s-f7f743024dae": 1
+       "698af8bf4ae827e4": 1,
+       "a319ba6503b07536": 1,
+       "a3270e361274cf79": 1,
+       "d03b19227ad2e030": 1,
+       "d37fedba38bd084f": 1,
+       "fec53ef1f739c6ff": -5
       }
      }
     }
@@ -19484,7 +19484,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-ddf57d4ff7ae"
+    "a4235e732a5b6af1"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19512,8 +19512,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-22cb833c3a91": 1,
-       "s-ddf57d4ff7ae": -1
+       "a4235e732a5b6af1": -1,
+       "dce6c17e2b914157": 1
       }
      }
     }
@@ -19527,7 +19527,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-c0901266a4ae"
+    "3f24a44d0e1de94a"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19559,8 +19559,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-c0901266a4ae": -1,
-       "s-f4e347ee8890": 1
+       "3f24a44d0e1de94a": -1,
+       "45a669ef47d11d4d": 1
       }
      }
     }
@@ -19574,9 +19574,9 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-54157723a522",
-    "s-1d824c3938c0",
-    "s-aca923ccd98c"
+    "8e39c4efe222e71c",
+    "95a2028bc75142db",
+    "e3f9cabb60984f58"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19604,16 +19604,16 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-08d0b049753a": 1,
-       "s-1d824c3938c0": -8,
-       "s-44b93795d745": 2,
-       "s-9eef970b9b50": 2,
-       "s-a6078d0d41e7": 1,
-       "s-aca923ccd98c": -4,
-       "s-adb23efa7c8a": 1,
-       "s-c28f79b475aa": 1,
-       "s-ea867909bdbe": 2,
-       "s-eeb2ab38e3ed": 2
+       "03cc8ab71b3df321": 2,
+       "0622c6652ca98244": 1,
+       "588987617908d7a6": 1,
+       "72fd07c43f1651cc": 1,
+       "8e39c4efe222e71c": -8,
+       "c940ce09aaa2a557": 2,
+       "d05e04892b679f6f": 2,
+       "d75d09c03a7002c3": 1,
+       "d804970dd4930d7a": 2,
+       "e3f9cabb60984f58": -4
       }
      }
     }
@@ -19627,7 +19627,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-b3c171f37727"
+    "9e5ee4e139e58796"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19655,10 +19655,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-500ccb1638d2": 1,
-       "s-b3c171f37727": -3,
-       "s-ce6f4cc3a264": 1,
-       "s-e64a4e845250": 1
+       "08eed191ef93cc16": 1,
+       "9e5ee4e139e58796": -3,
+       "c038d08c3250074e": 1,
+       "de54d7ef9ecd8c87": 1
       }
      }
     }
@@ -19672,7 +19672,7 @@
    "n_flipped_items": 1,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "s-92e8533d3b1b"
+    "a32e49ffa87048c0"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19704,11 +19704,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-165a15625ee4": 1,
-       "s-58c775a74778": 1,
-       "s-617413be7236": 1,
-       "s-92e8533d3b1b": -4,
-       "s-df007c78e928": 1
+       "66139f9b218a88f3": 1,
+       "6e7fc5bb1bbe3deb": 1,
+       "704d35a36a507fc0": 1,
+       "a32e49ffa87048c0": -4,
+       "e8251106923790b5": 1
       }
      }
     }
@@ -19722,10 +19722,10 @@
    "n_flipped_items": 4,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "r-306e7486828f",
-    "r-76515fa230c1",
-    "r-83fb6cc39b4a",
-    "s-d719e79d2008"
+    "0502216aa0ff7bea",
+    "3e33a86266f67a99",
+    "64e2813bba56be33",
+    "b557c08ae1475206"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19753,9 +19753,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-1b5ef4766b05": 1,
-       "s-c8b925718e9f": 1,
-       "s-d719e79d2008": -2
+       "28ce742c3c8d46e6": 1,
+       "64e2813bba56be33": -2,
+       "97d714cabb74e256": 1
       }
      }
     }
@@ -19769,9 +19769,9 @@
    "n_flipped_items": 9,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "o-584f87a6e6ff",
-    "r-76437c462918",
-    "s-83e89144cb27"
+    "1c6d2bf7ecc53ae3",
+    "4d162194f9faacb7",
+    "79f3f1385a3ad475"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19805,11 +19805,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-535c522dd09b": 1,
-       "s-699ae47ec3ee": 1,
-       "s-83e89144cb27": -4,
-       "s-f35978b781b0": 1,
-       "s-f6de5ed82b34": 1
+       "1c6d2bf7ecc53ae3": -4,
+       "51d91a8ea9f3fa85": 1,
+       "64f61e92d0fbaf54": 1,
+       "7130f5eec4a9b1ed": 1,
+       "9072ecc95365671e": 1
       }
      }
     }
@@ -19823,10 +19823,10 @@
    "n_flipped_items": 13,
    "n_lid_biting_flips": 4,
    "lid_biting_items": [
-    "o-515dbfd4d77e",
-    "r-8340d197fd58",
-    "s-7263c9f4b781",
-    "u-327e841c186d"
+    "146afbe238f88093",
+    "1ebe7532035d10d0",
+    "749c644014355603",
+    "81a6b4f0399954ef"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19858,11 +19858,11 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-515dbfd4d77e": -4,
-       "o-7b0dbaa567b3": 1,
-       "o-bdb0fd592ff3": 1,
-       "o-bf54b43c19c1": 1,
-       "o-f9d3e0bed4d4": 1
+       "749c644014355603": -4,
+       "b0608b11b17543c4": 1,
+       "b7a530367579ccb5": 1,
+       "e775c2efb04235be": 1,
+       "eaa3e8c1dc5f7fe1": 1
       }
      }
     },
@@ -19878,8 +19878,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-7263c9f4b781": -1,
-       "s-f888d3450938": 1
+       "1ebe7532035d10d0": -1,
+       "535781fe598f2610": 1
       }
      }
     },
@@ -19895,9 +19895,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "u-29ee66c455e2": 1,
-       "u-327e841c186d": -2,
-       "u-a9d0c95c96d0": 1
+       "146afbe238f88093": -2,
+       "bcf9a0de6a80e742": 1,
+       "e9e09c658e7e29e7": 1
       }
      }
     }
@@ -19911,7 +19911,7 @@
    "n_flipped_items": 13,
    "n_lid_biting_flips": 1,
    "lid_biting_items": [
-    "o-515dbfd4d77e"
+    "749c644014355603"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19943,8 +19943,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-515dbfd4d77e": -1,
-       "o-7b0dbaa567b3": 1
+       "749c644014355603": -1,
+       "e775c2efb04235be": 1
       }
      }
     }
@@ -19958,8 +19958,8 @@
    "n_flipped_items": 2,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "s-54ae239c88dc",
-    "s-874349590b87"
+    "1b83f518554e910e",
+    "308806739f5a00b2"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -19993,10 +19993,10 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-54ae239c88dc": -1,
-       "s-874349590b87": -2,
-       "s-881099e29989": 2,
-       "s-9b4f7f1e1d7d": 1
+       "18f9533fbece7097": 1,
+       "1b83f518554e910e": -2,
+       "308806739f5a00b2": -1,
+       "6e5ccae840424a60": 2
       }
      }
     }
@@ -20010,8 +20010,8 @@
    "n_flipped_items": 8,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "r-cd0c8950dc84",
-    "s-ed1cc815927c"
+    "09086e2b06b980b9",
+    "565b7a81d2401246"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -20039,8 +20039,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-4e26d42f9eb7": 1,
-       "s-ed1cc815927c": -1
+       "565b7a81d2401246": -1,
+       "c443376de39cf7cd": 1
       }
      }
     }
@@ -20054,8 +20054,8 @@
    "n_flipped_items": 13,
    "n_lid_biting_flips": 2,
    "lid_biting_items": [
-    "o-a28fe6edb0dd",
-    "r-1156e3b268b0"
+    "3d96b69153977b6a",
+    "e1168ab3f64f3308"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -20091,8 +20091,8 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "o-a28fe6edb0dd": -1,
-       "o-b13c228d0e1e": 1
+       "353285cfa182d443": 1,
+       "3d96b69153977b6a": -1
       }
      }
     }
@@ -20106,9 +20106,9 @@
    "n_flipped_items": 12,
    "n_lid_biting_flips": 3,
    "lid_biting_items": [
-    "r-ee1054e42e0b",
-    "s-658b952291cc",
-    "s-db7a5f8f012a"
+    "21582cd04c4a5286",
+    "811bbeabeac90f63",
+    "c39618f1c798f546"
    ],
    "n_truncation_exempting_flips": 0,
    "truncation_exempting_items": [],
@@ -20133,10 +20133,10 @@
      "cap_crossings": {
       "count": 2,
       "only_gated": [
-       "s-d76f869b470c"
+       "eb9b1cb4b1e58f49"
       ],
       "only_ungated": [
-       "s-db7a5f8f012a"
+       "c39618f1c798f546"
       ]
      },
      "rank_diff": {
@@ -20144,9 +20144,9 @@
       "items_in": [],
       "items_out": [],
       "rank_deltas": {
-       "s-658b952291cc": -1,
-       "s-d76f869b470c": 2,
-       "s-db7a5f8f012a": -1
+       "811bbeabeac90f63": -1,
+       "c39618f1c798f546": -1,
+       "eb9b1cb4b1e58f49": 2
       }
      }
     }

--- a/research/experiments/trust-gate-cost-976/measurements.json
+++ b/research/experiments/trust-gate-cost-976/measurements.json
@@ -1,0 +1,20156 @@
+{
+ "issue": 976,
+ "pre_registration": "Design - Trust Gate Cost Experiment 2026-09-12",
+ "inputs": {
+  "bench": {
+   "stores": 54,
+   "files": 2901,
+   "sha256": "bdfc6901ee5b783c702694a4cb265c5c855e8ac2b41c5e4751c133f5dcbad8ef"
+  },
+  "local": {
+   "present": true,
+   "files": 684,
+   "sha256": "7169a1e87fa2bfd50b1ccbd5819106e2f54f032f46a4b390bf7172196140705f"
+  }
+ },
+ "summary": {
+  "suggest": {
+   "prompts": 54,
+   "fired": {
+    "k": 44,
+    "n": 54,
+    "rate": 0.814815,
+    "wilson95": [
+     0.691638,
+     0.896174
+    ]
+   },
+   "differing": {
+    "k": 0,
+    "n": 54,
+    "rate": 0.0,
+    "wilson95": [
+     0.0,
+     0.066416
+    ]
+   },
+   "flipped_items": 726,
+   "lid_biting_flips": 372,
+   "differences_with_a_lid_biting_flip": 0,
+   "limits": [
+    2,
+    5
+   ]
+  },
+  "briefing": {
+   "checkpoints": 3585,
+   "comparisons": 6602,
+   "measured": 6600,
+   "empty": 2,
+   "skipped_no_created": 284,
+   "over_budget": {
+    "k": 564,
+    "n": 6600,
+    "rate": 0.085455,
+    "wilson95": [
+     0.078949,
+     0.092443
+    ]
+   },
+   "differing": {
+    "k": 320,
+    "n": 6600,
+    "rate": 0.048485,
+    "wilson95": [
+     0.04356,
+     0.053935
+    ]
+   },
+   "positions_changed": 2300,
+   "cap_crossings": 119,
+   "flipped_items": 4936,
+   "lid_biting_flips": 1971,
+   "differences_with_a_lid_biting_flip": 319,
+   "truncation_exempting_flips": 42,
+   "differences_with_a_truncation_exempting_flip": 15,
+   "differences_with_neither_channel": 0,
+   "horizons_days": [
+    1,
+    30
+   ],
+   "by_horizon": {
+    "1": {
+     "flips": 2468,
+     "lid_biting": 1887,
+     "lid_biting_fraction": {
+      "k": 1887,
+      "n": 2468,
+      "rate": 0.764587,
+      "wilson95": [
+       0.747445,
+       0.780906
+      ]
+     }
+    },
+    "30": {
+     "flips": 2468,
+     "lid_biting": 84,
+     "lid_biting_fraction": {
+      "k": 84,
+      "n": 2468,
+      "rate": 0.034036,
+      "wilson95": [
+       0.027575,
+       0.041945
+      ]
+     }
+    }
+   }
+  },
+  "lid_knee": 0.63,
+  "lid_biting_fraction_of_flips": {
+   "k": 2343,
+   "n": 5662,
+   "rate": 0.413811,
+   "wilson95": [
+    0.401045,
+    0.426695
+   ]
+  },
+  "lid_biting_fraction_by_surface": {
+   "suggest": {
+    "k": 372,
+    "n": 726,
+    "rate": 0.512397,
+    "wilson95": [
+     0.476067,
+     0.548596
+    ]
+   },
+   "briefing": {
+    "k": 1971,
+    "n": 4936,
+    "rate": 0.399311,
+    "wilson95": [
+     0.385731,
+     0.413047
+    ]
+   }
+  },
+  "P1_every_difference_traces_to_a_lid_biting_flip": false,
+  "P1_every_difference_traces_to_a_measured_channel": true,
+  "P2_lid_biting_fraction_is_single_digit_percent": false
+ },
+ "suggest": [
+  {
+   "question_id": "e47becba",
+   "now": 1704156720.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "6f9b354f",
+   "now": 1704156540.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 51,
+   "n_lid_biting_flips": 44,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "66f24dbb",
+   "now": 1704156540.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 16,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "dccbc061",
+   "now": 1704156480.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 1,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "c8c3f81d",
+   "now": 1704156660.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "d52b4f67",
+   "now": 1704156660.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 39,
+   "n_lid_biting_flips": 36,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "25e5aa4f",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 38,
+   "n_lid_biting_flips": 28,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "60d45044",
+   "now": 1704156600.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 7,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "86b68151",
+   "now": 1704156360.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "e01b8e2f",
+   "now": 1704156720.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 20,
+   "n_lid_biting_flips": 8,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "b320f3f8",
+   "now": 1704156300.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 7,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "19b5f2b3",
+   "now": 1704156120.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 0,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "4fd1909e",
+   "now": 1704156840.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 17,
+   "n_lid_biting_flips": 7,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "545bd2b5",
+   "now": 1704156180.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "76d63226",
+   "now": 1704156420.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 1,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "86f00804",
+   "now": 1704156120.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 1,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "4100d0a0",
+   "now": 1704156540.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 7,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "a82c026e",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "bc8a6e93_abs",
+   "now": 1704156360.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "6d550036",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 31,
+   "n_lid_biting_flips": 17,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_59c863d7",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 15,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "3a704032",
+   "now": 1704156420.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_d84a3211",
+   "now": 1704156420.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "7024f17c",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 20,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_5501fe77",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_2ba83207",
+   "now": 1704156720.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "2318644b",
+   "now": 1704156000.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 18,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "2788b940",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "a9f6b44c",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 22,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "d851d5ba",
+   "now": 1704156300.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_ab202e7f",
+   "now": 1704156300.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "1a8a66a6",
+   "now": 1704156600.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 0,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "bf659f65",
+   "now": 1704156660.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 25,
+   "n_lid_biting_flips": 13,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_372c3eed",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 40,
+   "n_lid_biting_flips": 27,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "gpt4_2f91af09",
+   "now": 1704156720.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 55,
+   "n_lid_biting_flips": 46,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "eeda8a6d_abs",
+   "now": 1704156480.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "8a2466db",
+   "now": 1704156540.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "06878be2",
+   "now": 1704156420.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "caf03d32",
+   "now": 1704156600.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 6,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "54026fce",
+   "now": 1704156480.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "1a1907b4",
+   "now": 1704156420.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "d24813b1",
+   "now": 1704156180.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 0,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "57f827a0",
+   "now": 1704156600.0,
+   "fired": false,
+   "identical": true,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 0,
+     "n_ungated": 0,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "95228167",
+   "now": 1704156480.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "fca70973",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 4,
+     "n_ungated": 4,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "b6025781",
+   "now": 1704156360.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "1d4e3b97",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 2,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 5,
+     "n_ungated": 5,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "0a34ad58",
+   "now": 1704156060.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "d3ab962e",
+   "now": 1704156480.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 0,
+   "by_limit": {
+    "2": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 1,
+     "n_ungated": 1,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "2311e44b",
+   "now": 1704156540.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 4,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "4f54b7c9",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 7,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "1f2b8d4f",
+   "now": 1704156600.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 5,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 3,
+     "n_ungated": 3,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "e6041065",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 0,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  },
+  {
+   "question_id": "4adc0475",
+   "now": 1704156240.0,
+   "fired": true,
+   "identical": true,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 3,
+   "by_limit": {
+    "2": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    },
+    "5": {
+     "n_gated": 2,
+     "n_ungated": 2,
+     "identical": true,
+     "items_in": [],
+     "items_out": [],
+     "rank_deltas": {}
+    }
+   },
+   "responsible": []
+  }
+ ],
+ "briefing": [
+  {
+   "checkpoint": "e47becba/e27891d3_2.json",
+   "source": "bench:e47becba",
+   "horizon_days": 1,
+   "now": 1704156540.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-1e3827"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1613ed": 1,
+       "s-1e3827": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "e47becba/sharegpt_qRdLQvN_7.json",
+   "source": "bench:e47becba",
+   "horizon_days": 1,
+   "now": 1704154080.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-768ef5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-768ef5": -1,
+       "o-907d3a": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/36828c66_2.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704154020.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "h:c4943862a3d9",
+    "o-38c93b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-38c93b": -1,
+       "o-d36d88": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/36828c66_2.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 30,
+   "now": 1706659620.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-38c93b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-38c93b": -1,
+       "o-d36d88": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/54d06eeb.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704153600.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-24eea5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-24eea5": -1,
+       "s-39c9f0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/8bc305e4_1.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704154980.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-191fc9",
+    "s-587119",
+    "s-a0c80b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-587119": -2,
+       "s-5aee02": 2,
+       "s-a0c80b": -2,
+       "s-cf2025": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/a729934a_2.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704156060.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-251a73"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1a0cbc": 1,
+       "s-251a73": -2,
+       "s-b67e50": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/sharegpt_KwbJJ66_18.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704156000.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-de3b03",
+    "s-4c1f6b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1d617c": 1,
+       "s-4c1f6b": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "6f9b354f/sharegpt_kRjBUsA_79.json",
+   "source": "bench:6f9b354f",
+   "horizon_days": 1,
+   "now": 1704155220.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-8309d3",
+    "s-e5d3eb"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-b032c6": 1,
+       "s-e5d3eb": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "66f24dbb/sharegpt_CYcAuWq_0.json",
+   "source": "bench:66f24dbb",
+   "horizon_days": 1,
+   "now": 1704155820.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-2e6a07",
+    "r-6a040b",
+    "r-8bbb22",
+    "s-cef9dd"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-584d35": 1,
+       "s-cef9dd": -2,
+       "s-e54430": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "66f24dbb/ultrachat_366348.json",
+   "source": "bench:66f24dbb",
+   "horizon_days": 1,
+   "now": 1704155340.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-f13eae"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5c58b4": 1,
+       "s-6d85a8": 1,
+       "s-d4f167": 1,
+       "s-dd60dc": 1,
+       "s-f13eae": -5,
+       "s-f85d14": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "dccbc061/sharegpt_MKMWjX0_25.json",
+   "source": "bench:dccbc061",
+   "horizon_days": 1,
+   "now": 1704155340.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-ab070c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-939c11": 1,
+       "s-ab070c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "dccbc061/sharegpt_sZKME3y_0.json",
+   "source": "bench:dccbc061",
+   "horizon_days": 1,
+   "now": 1704156060.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-6d0b8f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6d0b8f": -1,
+       "s-e25065": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "c8c3f81d/0554bd9d_1.json",
+   "source": "bench:c8c3f81d",
+   "horizon_days": 1,
+   "now": 1704156000.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-824fdf"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3a1eac": 1,
+       "s-469143": 1,
+       "s-824fdf": -3,
+       "s-b6b0e8": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "c8c3f81d/ultrachat_269520.json",
+   "source": "bench:c8c3f81d",
+   "horizon_days": 1,
+   "now": 1704155880.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-e935a1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-108c24": 1,
+       "s-b2eea7": 1,
+       "s-e935a1": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/9b17bb98.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704154980.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-845fdb",
+    "s-0eb375"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-47876a": 1,
+       "o-845fdb": -2,
+       "o-b1fbd1": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/c964b460_1.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704156180.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "h:328cece78696",
+    "s-c233ac"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-ae8828": 1,
+       "s-c233ac": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/sharegpt_IqVsDp7_89.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704155280.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "h:ce0d3ced273f",
+    "s-1738fd"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1738fd": -1,
+       "s-5d32f7": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/ultrachat_181957.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704153960.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-95dce9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-95dce9": -1,
+       "o-eb060b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/ultrachat_181957.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 30,
+   "now": 1706659560.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-95dce9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-95dce9": -1,
+       "o-eb060b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/ultrachat_311844.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704154800.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "h:08327ea43411",
+    "r-d8c96c",
+    "s-477d94"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-477d94": -1,
+       "s-881cb2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/ultrachat_416577.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 1,
+   "now": 1704155580.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-23d75e",
+    "r-ce3c73"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-23d75e": -3,
+       "o-8defc2": 1,
+       "o-8e35a9": 1,
+       "o-b52e53": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "d52b4f67/ultrachat_416577.json",
+   "source": "bench:d52b4f67",
+   "horizon_days": 30,
+   "now": 1706661180.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-23d75e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-23d75e": -1,
+       "o-8defc2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/47183c60_2.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704154140.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-2e77c7",
+    "o-ef1436"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2e77c7": -1,
+       "o-aa11b4": 2,
+       "o-ef1436": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/47183c60_2.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 30,
+   "now": 1706659740.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-2e77c7",
+    "o-ef1436"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2e77c7": -1,
+       "o-aa11b4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/74d3b557_2.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704154860.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "h:64fa4f583b5b",
+    "s-35ae27"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-35ae27": -1,
+       "s-cac9f1": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/ca5ff3b4.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704154800.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-947ab0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-621795": 1,
+       "s-947ab0": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/d22ef93f.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704156180.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "h:aca0a6921b61",
+    "o-004435",
+    "o-1a54bf",
+    "s-50c82a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-004435": -1,
+       "o-08b46d": 2,
+       "o-1a54bf": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-17e0a8": 1,
+       "s-50c82a": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/sharegpt_8cFNcVG_0.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704155400.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-461312",
+    "s-57abe1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-430a3a": 1,
+       "s-57abe1": -2,
+       "s-7ca42b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/sharegpt_Db9cdoK_0.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704154020.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-9976fb",
+    "s-70e5f2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3e9745": 1,
+       "s-70e5f2": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "25e5aa4f/ultrachat_225537.json",
+   "source": "bench:25e5aa4f",
+   "horizon_days": 1,
+   "now": 1704155040.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-b8a3a3",
+    "s-6c08e3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6637d5": 1,
+       "s-6c08e3": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "60d45044/ultrachat_532690.json",
+   "source": "bench:60d45044",
+   "horizon_days": 1,
+   "now": 1704154740.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-144101"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-144101": -2,
+       "s-46ef7f": 1,
+       "s-bb9999": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "e01b8e2f/b2543a58_3.json",
+   "source": "bench:e01b8e2f",
+   "horizon_days": 1,
+   "now": 1704156600.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-ec9c78"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-55a5f0": 1,
+       "s-879b2e": 1,
+       "s-ec9c78": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "e01b8e2f/sharegpt_GcMTqnA_5.json",
+   "source": "bench:e01b8e2f",
+   "horizon_days": 1,
+   "now": 1704156360.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "h:df492a18566d",
+    "o-4d52cc",
+    "s-5d2f97",
+    "s-631e49",
+    "s-7f1b1f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-3de466": 1,
+       "o-4d52cc": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5d2f97": -1,
+       "s-631e49": -1,
+       "s-7f1b1f": -1,
+       "s-a8f215": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "e01b8e2f/sharegpt_jyMHY1J_31.json",
+   "source": "bench:e01b8e2f",
+   "horizon_days": 1,
+   "now": 1704155400.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "o-7ad1eb",
+    "o-a1538e",
+    "r-1f114b",
+    "r-5a51f0",
+    "r-738951",
+    "s-9fc158"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0bf78b": 2,
+       "o-7ad1eb": -1,
+       "o-a1538e": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "b320f3f8/ultrachat_19047.json",
+   "source": "bench:b320f3f8",
+   "horizon_days": 1,
+   "now": 1704154140.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-7283c8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2bec08": 1,
+       "s-4620a8": 1,
+       "s-474a02": 1,
+       "s-6ad1e5": 1,
+       "s-7283c8": -6,
+       "s-b53916": 1,
+       "s-f1354e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4fd1909e/7032ebca_2.json",
+   "source": "bench:4fd1909e",
+   "horizon_days": 1,
+   "now": 1704154920.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-69a1e5",
+    "s-2b3076"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2b3076": -2,
+       "s-48b495": 1,
+       "s-4f98b9": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4fd1909e/sharegpt_NxG2nGm_298.json",
+   "source": "bench:4fd1909e",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-692a64",
+    "s-adc7cd"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1350d1": 2,
+       "s-692a64": -2,
+       "s-9bebfd": 1,
+       "s-adc7cd": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4fd1909e/sharegpt_Y6XO6Br_0.json",
+   "source": "bench:4fd1909e",
+   "horizon_days": 1,
+   "now": 1704155760.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-cdfd21",
+    "s-48ed00"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-48ed00": -4,
+       "s-561f30": 1,
+       "s-5825a2": 1,
+       "s-af7fdf": 1,
+       "s-bdc1b2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "545bd2b5/sharegpt_Q9HjD2H_0.json",
+   "source": "bench:545bd2b5",
+   "horizon_days": 1,
+   "now": 1704154560.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-0fb1e8",
+    "s-d202b6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-9ab014": 1,
+       "s-b5f904": 1,
+       "s-c6c9b3": 1,
+       "s-c83a70": 1,
+       "s-d202b6": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "76d63226/sharegpt_79vV0aT_377.json",
+   "source": "bench:76d63226",
+   "horizon_days": 1,
+   "now": 1704156360.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-fa41fa"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-58bf67": 1,
+       "s-c7dfd5": 1,
+       "s-ea152c": 1,
+       "s-fa41fa": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4100d0a0/4aa29855.json",
+   "source": "bench:4100d0a0",
+   "horizon_days": 1,
+   "now": 1704155760.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-a2a427"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-77c741": 1,
+       "s-a2a427": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4100d0a0/ultrachat_269520.json",
+   "source": "bench:4100d0a0",
+   "horizon_days": 1,
+   "now": 1704154500.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-e935a1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-108c24": 1,
+       "s-b2eea7": 1,
+       "s-e935a1": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4100d0a0/ultrachat_95444.json",
+   "source": "bench:4100d0a0",
+   "horizon_days": 1,
+   "now": 1704156300.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-d777b4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-63d6db": 1,
+       "s-d777b4": -2,
+       "s-ddf142": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "a82c026e/prev-1.json",
+   "source": "bench:a82c026e",
+   "horizon_days": 1,
+   "now": 1704156360.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-41a7ae",
+    "s-d11293"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-41a7ae": -1,
+       "s-7a5e46": 2,
+       "s-d11293": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "a82c026e/prev-1.json",
+   "source": "bench:a82c026e",
+   "horizon_days": 1,
+   "now": 1704156360.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-41a7ae",
+    "s-d11293"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-41a7ae": -1,
+       "s-7a5e46": 2,
+       "s-d11293": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_59c863d7/answer_593bdffd_2.json",
+   "source": "bench:gpt4_59c863d7",
+   "horizon_days": 1,
+   "now": 1704156180.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-3477e2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3477e2": -2,
+       "s-3e6789": 1,
+       "s-c3e0ce": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_59c863d7/sharegpt_StUzdLK_117.json",
+   "source": "bench:gpt4_59c863d7",
+   "horizon_days": 1,
+   "now": 1704156300.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-c92929"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-b22377": 1,
+       "s-c92929": -3,
+       "s-d6067e": 1,
+       "s-f50d03": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_59c863d7/sharegpt_sZKME3y_0.json",
+   "source": "bench:gpt4_59c863d7",
+   "horizon_days": 1,
+   "now": 1704155340.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-6d0b8f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6d0b8f": -1,
+       "s-e25065": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "3a704032/38e81260_5.json",
+   "source": "bench:3a704032",
+   "horizon_days": 1,
+   "now": 1704154440.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-9c6795"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-877b3a": 1,
+       "s-9c6795": -2,
+       "s-f077bc": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "3a704032/54d06eeb.json",
+   "source": "bench:3a704032",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-24eea5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-24eea5": -1,
+       "s-39c9f0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_d84a3211/d1b9993e_2.json",
+   "source": "bench:gpt4_d84a3211",
+   "horizon_days": 1,
+   "now": 1704155580.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-f4b60c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-76f39e": 1,
+       "s-f4b60c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "7024f17c/sharegpt_rshCiS5_1.json",
+   "source": "bench:7024f17c",
+   "horizon_days": 1,
+   "now": 1704154980.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-67462e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-d6417a"
+      ],
+      "only_ungated": [
+       "s-67462e"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3315b1": 1,
+       "s-613b85": 1,
+       "s-67462e": -4,
+       "s-ba0417": 1,
+       "s-d6417a": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2ba83207/ultrachat_224880.json",
+   "source": "bench:gpt4_2ba83207",
+   "horizon_days": 1,
+   "now": 1704154320.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-2d669b",
+    "s-38885d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-112f9a": 2,
+       "s-187ccc": 2,
+       "s-2d669b": -6,
+       "s-38885d": -4,
+       "s-97cd4f": 1,
+       "s-a6815b": 2,
+       "s-c578e6": 1,
+       "s-d32b71": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "2318644b/7ff89315_3.json",
+   "source": "bench:2318644b",
+   "horizon_days": 1,
+   "now": 1704153720.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "h:bde37e2c9092",
+    "r-292014",
+    "s-902171"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-226b1f": 1,
+       "s-902171": -2,
+       "s-9ad651": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "a9f6b44c/ultrachat_468681.json",
+   "source": "bench:a9f6b44c",
+   "horizon_days": 1,
+   "now": 1704155220.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "s-1f5d50",
+    "s-43b611",
+    "s-7ef59c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1f5d50": -1,
+       "s-2550ff": 3,
+       "s-43b611": -1,
+       "s-7ef59c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_ab202e7f/10541a2c_2.json",
+   "source": "bench:gpt4_ab202e7f",
+   "horizon_days": 1,
+   "now": 1704155400.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-6cf978"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6cf978": -1,
+       "s-f04962": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1a8a66a6/prev-1.json",
+   "source": "bench:1a8a66a6",
+   "horizon_days": 1,
+   "now": 1704156540.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-32302b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-32302b": -1,
+       "s-e72eb4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1a8a66a6/dc71023e.json",
+   "source": "bench:1a8a66a6",
+   "horizon_days": 1,
+   "now": 1704156540.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-32302b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-32302b": -1,
+       "s-e72eb4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1a8a66a6/prev-1.json",
+   "source": "bench:1a8a66a6",
+   "horizon_days": 1,
+   "now": 1704156540.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-32302b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-32302b": -1,
+       "s-e72eb4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "bf659f65/sharegpt_8cFNcVG_0.json",
+   "source": "bench:bf659f65",
+   "horizon_days": 1,
+   "now": 1704154860.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-461312",
+    "s-57abe1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-430a3a": 1,
+       "s-57abe1": -2,
+       "s-7ca42b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "bf659f65/sharegpt_FdbDo9h_11.json",
+   "source": "bench:bf659f65",
+   "horizon_days": 1,
+   "now": 1704155880.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-fa78e5",
+    "s-3bf1d9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-20c453": 1,
+       "s-3bf1d9": -4,
+       "s-52731c": 1,
+       "s-a115ef": 1,
+       "s-d91b7c": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "bf659f65/ultrachat_370839.json",
+   "source": "bench:bf659f65",
+   "horizon_days": 1,
+   "now": 1704156540.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-bb40ce"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-19a066": 1,
+       "s-bb40ce": -2,
+       "s-e8c3b4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/8dd672a3_3.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-92883c",
+    "r-397b7c",
+    "s-21f8e0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-7cd552": 1,
+       "o-92883c": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-21f8e0": -2,
+       "s-64b322": 1,
+       "s-dcd61a": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/answer_35c5419d_2.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 1,
+   "now": 1704155100.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-c5d633",
+    "s-009473"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-009473": -2,
+       "s-e34bf3": 1,
+       "s-e7d283": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/sharegpt_2hMUduQ_1.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 1,
+   "now": 1704153600.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-868dc6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-109ad4": 1,
+       "s-868dc6": -2,
+       "s-e45c1a": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/ultrachat_105960.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 1,
+   "now": 1704155940.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "h:56637375da27",
+    "o-b6f4ac"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-b6f4ac": -1,
+       "o-d9115d": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/ultrachat_105960.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 30,
+   "now": 1706661540.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-b6f4ac"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-b6f4ac": -1,
+       "o-d9115d": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_372c3eed/ultrachat_209842.json",
+   "source": "bench:gpt4_372c3eed",
+   "horizon_days": 1,
+   "now": 1704153960.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-5b80d0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5b80d0": -1,
+       "s-a10142": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/22b3af37_1.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "o-5a7ac6",
+    "r-186edd",
+    "r-982fb3",
+    "r-c0ac38",
+    "r-ec097d",
+    "r-f7028e",
+    "s-6da42a",
+    "s-7512e4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6da42a": -1,
+       "s-7512e4": -2,
+       "s-d60767": 1,
+       "s-f63a94": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/answer_669318cf_2.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704154020.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-eee3b8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-03953a": 1,
+       "s-79571b": 1,
+       "s-eee3b8": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/e7e416f5_2.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704153780.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-4cb1d0",
+    "s-26e72f",
+    "s-b6778c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-26e72f": -2,
+       "s-5a7489": 1,
+       "s-ada4ab": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/fd6f60f0_2.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704153660.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-4f94f7",
+    "s-b500b1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-8c91de": 1,
+       "s-a61d93": 1,
+       "s-b500b1": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/sharegpt_7jNclxT_45.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704156600.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-0cf82d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0cf82d": -2,
+       "o-45b1a3": 1,
+       "o-9e62c6": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/ultrachat_187458.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704155280.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "h:67c25293982d",
+    "r-2f6ac7",
+    "r-604e19",
+    "r-6a6f82",
+    "r-e6f3ab",
+    "s-991a07"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-29bd0e": 1,
+       "s-991a07": -2,
+       "s-ebf4f3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "gpt4_2f91af09/ultrachat_63063.json",
+   "source": "bench:gpt4_2f91af09",
+   "horizon_days": 1,
+   "now": 1704154680.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-fef9db",
+    "s-15fcfb"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-15fcfb": -2,
+       "s-5f038e": 1,
+       "s-a372ca": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "8a2466db/sharegpt_DwfIyV9_0.json",
+   "source": "bench:8a2466db",
+   "horizon_days": 1,
+   "now": 1704154680.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-0b5a6d",
+    "s-e31a15"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0b5a6d": -1,
+       "s-80d8a3": 1,
+       "s-85c260": 1,
+       "s-948ee6": 1,
+       "s-e31a15": -4,
+       "s-eedc4e": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "8a2466db/sharegpt_MKMWjX0_25.json",
+   "source": "bench:8a2466db",
+   "horizon_days": 1,
+   "now": 1704153840.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-ab070c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-939c11": 1,
+       "s-ab070c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "06878be2/42165950_2.json",
+   "source": "bench:06878be2",
+   "horizon_days": 1,
+   "now": 1704155460.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-b2e83f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5270ae": 1,
+       "s-b2e83f": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "06878be2/sharegpt_Aoss4uB_41.json",
+   "source": "bench:06878be2",
+   "horizon_days": 1,
+   "now": 1704155160.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-9ec3e5",
+    "r-ec9dd4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-760ff3": 1,
+       "o-9ec3e5": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "54026fce/sharegpt_eCX8HJW_4.json",
+   "source": "bench:54026fce",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "h:cad8b926a522",
+    "s-2a0377",
+    "s-2c53a0",
+    "s-e96c5b",
+    "s-ee5f0f",
+    "s-f14e54"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2c53a0": -2,
+       "s-303c45": 2,
+       "s-92a99c": 1,
+       "s-e51036": 2,
+       "s-e96c5b": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1a1907b4/sharegpt_sORQfa5_0.json",
+   "source": "bench:1a1907b4",
+   "horizon_days": 1,
+   "now": 1704155640.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-c42317",
+    "r-8ccfd3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-6c5e87": 1,
+       "o-c42317": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "57f827a0/031061e6_3.json",
+   "source": "bench:57f827a0",
+   "horizon_days": 1,
+   "now": 1704155220.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-8222d3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3e5388": 1,
+       "s-8222d3": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "57f827a0/6e110a53_1.json",
+   "source": "bench:57f827a0",
+   "horizon_days": 1,
+   "now": 1704154740.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-baaec6",
+    "s-7288b2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-7288b2": -1,
+       "s-a461a2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "57f827a0/sharegpt_aVExml0_63.json",
+   "source": "bench:57f827a0",
+   "horizon_days": 1,
+   "now": 1704155100.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-2b22b7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2b22b7": -3,
+       "s-846292": 1,
+       "s-84701e": 1,
+       "s-ff1be2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "fca70973/sharegpt_CYcAuWq_0.json",
+   "source": "bench:fca70973",
+   "horizon_days": 1,
+   "now": 1704153840.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-2e6a07",
+    "r-6a040b",
+    "r-8bbb22",
+    "s-cef9dd"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-584d35": 1,
+       "s-cef9dd": -2,
+       "s-e54430": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "b6025781/ultrachat_311171.json",
+   "source": "bench:b6025781",
+   "horizon_days": 1,
+   "now": 1704154980.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-42706d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-400d24": 1,
+       "s-42706d": -7,
+       "s-4fcbba": 1,
+       "s-68504d": 1,
+       "s-7af424": 1,
+       "s-d4f689": 1,
+       "s-d6067f": 1,
+       "s-fb6510": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1d4e3b97/ecb24dd8_2.json",
+   "source": "bench:1d4e3b97",
+   "horizon_days": 1,
+   "now": 1704154260.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-3d5d2d",
+    "s-b3ca49"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3d5d2d": -1,
+       "s-b3ca49": -1,
+       "s-b9f5aa": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "0a34ad58/sharegpt_jv94ugh_0.json",
+   "source": "bench:0a34ad58",
+   "horizon_days": 1,
+   "now": 1704154740.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-3d99c1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-26c6e7": 1,
+       "s-3d99c1": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "2311e44b/573f14d0_1.json",
+   "source": "bench:2311e44b",
+   "horizon_days": 1,
+   "now": 1704154140.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-63bd17"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-63bd17": -1,
+       "s-73fb84": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4f54b7c9/49a91ed8.json",
+   "source": "bench:4f54b7c9",
+   "horizon_days": 1,
+   "now": 1704154620.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-57f696"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-57f696": -1,
+       "o-e73347": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/latest.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704156600.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-13aaa8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-13aaa8": -3,
+       "s-6dff4c": 1,
+       "s-a58c2f": 1,
+       "s-b1cbbb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/2eaf50f6_1.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704155460.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-dcb735"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-b525b6": 1,
+       "s-dcb735": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/76a39abc.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704156120.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "u-bea2fe"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "uncertainties": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-bea2fe": -2,
+       "u-c47fcc": 1,
+       "u-ebe03b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/c8c64252.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704156600.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-13aaa8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-13aaa8": -3,
+       "s-6dff4c": 1,
+       "s-a58c2f": 1,
+       "s-b1cbbb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/latest.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704156600.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-13aaa8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-13aaa8": -3,
+       "s-6dff4c": 1,
+       "s-a58c2f": 1,
+       "s-b1cbbb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/sharegpt_GzODe4q_0.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704155040.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-0f06e5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0f06e5": -1,
+       "o-e098a9": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/sharegpt_GzODe4q_0.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 30,
+   "now": 1706660640.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-0f06e5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0f06e5": -1,
+       "o-e098a9": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "1f2b8d4f/sharegpt_vGxp8Hq_0.json",
+   "source": "bench:1f2b8d4f",
+   "horizon_days": 1,
+   "now": 1704156360.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-f3571d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6a60db": 1,
+       "s-8d1d1a": 1,
+       "s-d1deec": 1,
+       "s-f3571d": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4adc0475/answer_6efce493_1.json",
+   "source": "bench:4adc0475",
+   "horizon_days": 1,
+   "now": 1704155220.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-f09533"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0c1815": 1,
+       "s-46ef78": 1,
+       "s-f09533": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "4adc0475/sharegpt_Ob4KIVf_0.json",
+   "source": "bench:4adc0475",
+   "horizon_days": 1,
+   "now": 1704155640.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-7523ef"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0341cc": 1,
+       "s-7523ef": -2,
+       "s-ab72d3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cecd8686b351cc6b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789337680.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-8e3a6c0e74df"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 5,
+     "uncertainties": 1
+    },
+    "ungated": {
+     "beliefs": 5,
+     "uncertainties": 1
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2c2200e04628": 1,
+       "o-837632290379": 1,
+       "o-8e3a6c0e74df": -4,
+       "o-beb29261b342": 1,
+       "o-f71a52246f2e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:fd71dce30014ec83",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789333699.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-3253a18a2154",
+    "r-aec21dbf131c",
+    "s-32dd7b72385e",
+    "s-bf358665add2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-8dbedbaaca57",
+       "s-b234b013d733"
+      ],
+      "only_ungated": [
+       "s-32dd7b72385e",
+       "s-bf358665add2"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-32dd7b72385e": -7,
+       "s-352a468d0fa1": 2,
+       "s-54eacaeab14f": 1,
+       "s-5af25ca91a9b": 2,
+       "s-635a8a71a8e6": 1,
+       "s-76371b591f6e": 2,
+       "s-8dbedbaaca57": 2,
+       "s-b234b013d733": 2,
+       "s-bf358665add2": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:82d72401d24de303",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789291557.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-d0246fc247f9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-d0246fc247f9": -2,
+       "s-d98d6f640ded": 1,
+       "s-f86a74f5f1b3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b26e48a32212aeae",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788250388.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-04fe20442c70",
+    "s-ae0ba2390fc8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-04fe20442c70": -1,
+       "s-787916be872e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cb4d83e20e5787e9",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788073929.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "o-a25007f4c6e3",
+    "r-304a4ed4f0d4",
+    "r-3b021e7ba8c5",
+    "r-4f62fd1dff95",
+    "r-bf4ee92d41bb",
+    "s-15609a6f3c71",
+    "s-4db06d37106e",
+    "s-615b988a4f25",
+    "s-7ac48c95c8b3",
+    "s-a4b2a6e5733c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 23
+    },
+    "ungated": {
+     "beliefs": 23
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-936972dfead1"
+      ],
+      "only_ungated": [
+       "s-a4b2a6e5733c"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-06961db383db": 5,
+       "s-15609a6f3c71": -2,
+       "s-4db06d37106e": -4,
+       "s-615b988a4f25": -3,
+       "s-6a6982330cce": 4,
+       "s-7ac48c95c8b3": -4,
+       "s-936972dfead1": 1,
+       "s-9c6e42d76a4a": 5,
+       "s-a4b2a6e5733c": -7,
+       "s-b605da8fdabe": 1,
+       "s-ba9ee60f1393": 1,
+       "s-cbd74b84ec45": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:adbb384bcc1aba76",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980945.0,
+   "n_flipped_items": 19,
+   "n_lid_biting_flips": 17,
+   "lid_biting_items": [
+    "h:99e42dfe2938",
+    "r-0f1d56e656b7",
+    "r-2009748f4cdb",
+    "r-6ad17412b0be",
+    "r-9731ddc4f174",
+    "r-9867c097bf4d",
+    "r-a3eaa03cf828",
+    "r-c044d7edb5f0",
+    "r-e69bc19bd0e6",
+    "s-04dece143d52",
+    "s-28643d000f9a",
+    "s-35697cf0a7b2",
+    "s-55cedf866b6f",
+    "s-730748221d37",
+    "s-8819f107781a",
+    "s-b6c81807b5e7",
+    "s-bafaa6b06351"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40,
+     "uncertainties": 21,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 40,
+     "uncertainties": 21,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 20,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 20,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-020468f1dfeb": 7,
+       "s-0225b0e6e55b": 4,
+       "s-04dece143d52": -5,
+       "s-216e1695c671": 5,
+       "s-28643d000f9a": -8,
+       "s-335347ed6e2b": 1,
+       "s-35697cf0a7b2": -3,
+       "s-375fc7c30a01": 3,
+       "s-55cedf866b6f": -5,
+       "s-652ea2ccda71": 4,
+       "s-730748221d37": -9,
+       "s-7969f3ade184": 3,
+       "s-861bb07a6014": 4,
+       "s-8819f107781a": -9,
+       "s-ad36fc031bb5": 7,
+       "s-b6c81807b5e7": -5,
+       "s-bac5f45c7579": 7,
+       "s-bafaa6b06351": -9,
+       "s-d4c29ad5eea3": 4,
+       "s-eda44702896b": 4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:12921efa51244514",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788566526.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 13,
+   "lid_biting_items": [
+    "h:4cbf0acbdd73",
+    "o-5b8df357c64d",
+    "r-01e87a33ad7a",
+    "r-05d4d3cb90ce",
+    "r-498681ab50a8",
+    "r-622ee6d6c2ed",
+    "r-782c8a1e7971",
+    "r-78726d23d29e",
+    "r-98f6a04559e7",
+    "r-c68c7be529ff",
+    "r-cfa70b9c6559",
+    "s-3662aca3c5e6",
+    "s-f1d0e84ff346"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-46389c74b8fe": 1,
+       "o-5b8df357c64d": -2,
+       "o-9ac19e49ba62": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6427f5243dfa": 1,
+       "s-7233d967d13e": 1,
+       "s-a2250fe46105": 1,
+       "s-f1d0e84ff346": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:df45add4955267f8",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341804.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-cd0c8950dc84",
+    "s-ed1cc815927c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-4e26d42f9eb7": 1,
+       "s-ed1cc815927c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d95b054239c49991",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789338734.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-cd0c8950dc84",
+    "s-7386c2726710",
+    "s-965ced9f8e9d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0da92b5b1402": 2,
+       "s-7386c2726710": -3,
+       "s-965ced9f8e9d": -4,
+       "s-982db6a12498": 1,
+       "s-aa347f598139": 2,
+       "s-e260ed2a610a": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7db888427ef06726",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788249133.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-47cbbb4fb209",
+    "s-27ac16e736ed",
+    "s-8188c7a828c4",
+    "s-9d94ac26b546",
+    "u-c6131e775fe4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0e9ba98943ff": 2,
+       "s-1a5f8c6eee8b": 3,
+       "s-27ac16e736ed": -1,
+       "s-3653d2277143": 2,
+       "s-8188c7a828c4": -4,
+       "s-9d94ac26b546": -4,
+       "s-ad6cdb000f74": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f201451ac728a665",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786082101.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "h:71680316bdb6",
+    "r-b474e2151408",
+    "s-3a94c506987c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3a94c506987c": -1,
+       "s-a91c3b98c508": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:df4dc6f9878d5a14",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788981127.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-1fd8f63ffc9a",
+    "r-50d6258c2050",
+    "r-64cc8d3673e9",
+    "s-5b8463ca4c3b",
+    "s-612b1eecc162",
+    "s-e2fded700c7a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2dc093e62750": 3,
+       "s-4eff64efc019": 2,
+       "s-5b8463ca4c3b": -2,
+       "s-612b1eecc162": -3,
+       "s-8140031f08ec": 3,
+       "s-e2fded700c7a": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3f3b371d87355678",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788208703.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-2c6bfd640474",
+    "r-2cfd99886915",
+    "r-cbb8e6798a8f",
+    "r-dda72a321849",
+    "r-fdaa730b26e3",
+    "s-95a34473f0db"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20
+    },
+    "ungated": {
+     "beliefs": 20
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-9e25870ae5a7"
+      ],
+      "only_ungated": [
+       "s-95a34473f0db"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0a0b9409d089": 1,
+       "s-1d844919adbe": 1,
+       "s-30dbf21dc389": 1,
+       "s-3afe38c7b37b": 1,
+       "s-4cc18a4f504b": 1,
+       "s-8c79a4474cb7": 1,
+       "s-95a34473f0db": -9,
+       "s-9e25870ae5a7": 1,
+       "s-a2daf26de8e8": 1,
+       "s-c9709620a88b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:5980dfc217be0294",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789114379.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-92e8533d3b1b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-165a15625ee4": 1,
+       "s-58c775a74778": 1,
+       "s-617413be7236": 1,
+       "s-92e8533d3b1b": -4,
+       "s-df007c78e928": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a7e187bf82e79fb9",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789113935.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-165cc577e14e",
+    "s-c72f6bb3e55d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 4,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-c72f6bb3e55d": -1,
+       "s-d0df47761f6c": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:34816dc5f0dfe83b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789176406.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-05d5cc118883",
+    "r-80b226337f04",
+    "s-3ad2e68c81e0",
+    "s-4fb7063ee795",
+    "s-85ad2f367e5b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3ad2e68c81e0": -1,
+       "s-3ee6cbe0cf39": 1,
+       "s-4fb7063ee795": -3,
+       "s-85ad2f367e5b": -1,
+       "s-8967aa99c960": 3,
+       "s-c990525d81c4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e12b325837e17698",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786592238.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-ad5991c7c565",
+    "s-1794685f8714"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1794685f8714": -5,
+       "s-85af95d36859": 1,
+       "s-861952d98dd3": 1,
+       "s-8d955adb3f80": 1,
+       "s-aed8a2b77fa7": 1,
+       "s-c9622f7b9bef": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:87dc1948500fe1a3",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785462243.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "o-138d96",
+    "s-24d88de82f58",
+    "s-4bd044ed8544",
+    "s-526cc12d9141",
+    "s-571e15bc61c3",
+    "s-6ac375c86e3b",
+    "s-7f47d142adcc",
+    "s-da3d1825074d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25
+    },
+    "ungated": {
+     "beliefs": 26
+    }
+   },
+   "positions_changed": 18,
+   "cap_crossings": 7,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 18,
+     "cap_crossings": {
+      "count": 7,
+      "only_gated": [
+       "s-001cdb652452",
+       "s-272ade03e625",
+       "s-47bb42e5b221",
+       "s-4ca6bae2daa8"
+      ],
+      "only_ungated": [
+       "s-526cc12d9141",
+       "s-6ac375c86e3b",
+       "s-da3d1825074d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-001cdb652452": 5,
+       "s-10325891c711": 7,
+       "s-1126a7afe8ac": 1,
+       "s-24d88de82f58": -3,
+       "s-272ade03e625": 5,
+       "s-47bb42e5b221": 4,
+       "s-4bd044ed8544": -5,
+       "s-4ca6bae2daa8": 3,
+       "s-526cc12d9141": -9,
+       "s-54788c3c1f0a": 6,
+       "s-571e15bc61c3": -2,
+       "s-578aaf1eac04": 5,
+       "s-6792676f8e89": 3,
+       "s-6ac375c86e3b": -9,
+       "s-74ac2f372644": 1,
+       "s-7f47d142adcc": -6,
+       "s-a1fcd3f977d1": 3,
+       "s-da3d1825074d": -9
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:dece174a18c18e1c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785462243.0,
+   "n_flipped_items": 24,
+   "n_lid_biting_flips": 23,
+   "lid_biting_items": [
+    "h:e348bd14a6a0",
+    "o-138d96",
+    "o-e3d6ed",
+    "r-0d9556",
+    "r-0ff515",
+    "r-268ef8",
+    "r-3935fc",
+    "r-4f86df",
+    "r-7008c5",
+    "r-92ccc5",
+    "r-9f3f62",
+    "r-a49e53",
+    "r-a525fd",
+    "r-c23d8c",
+    "r-c8487e",
+    "r-e73773",
+    "r-f8fa74",
+    "s-5aaeac",
+    "s-5bd7b8",
+    "s-612a68",
+    "s-8efa49",
+    "s-93d5a8",
+    "u-b1055f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 10
+    },
+    "ungated": {
+     "beliefs": 10
+    }
+   },
+   "positions_changed": 22,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-138d96": -7,
+       "o-4c5297": 1,
+       "o-569baf": 2,
+       "o-6774b0": 1,
+       "o-7dd51a": 1,
+       "o-9f9e46": 2,
+       "o-b4c702": 1,
+       "o-e3d6ed": -2,
+       "o-e989bf": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 13,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-140db4": 5,
+       "s-5aaeac": -6,
+       "s-5bd7b8": -8,
+       "s-6071cd": 5,
+       "s-612a68": -4,
+       "s-7fcf87": 2,
+       "s-83a8a4": 1,
+       "s-882206": 5,
+       "s-8efa49": -4,
+       "s-93d5a8": -4,
+       "s-a44b12": 2,
+       "s-a66475": 1,
+       "s-b99a2b": 5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:dece174a18c18e1c",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1787967843.0,
+   "n_flipped_items": 24,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-138d96",
+    "o-e3d6ed"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 10
+    },
+    "ungated": {
+     "beliefs": 10
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-138d96": -6,
+       "o-4c5297": 1,
+       "o-569baf": 1,
+       "o-6774b0": 1,
+       "o-7dd51a": 1,
+       "o-9f9e46": 1,
+       "o-b4c702": 1,
+       "o-e3d6ed": -1,
+       "o-e989bf": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9d6b78ed42b9f9e6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789260919.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-691764ddd72c",
+    "s-f52419c599b1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0fa50a112a7c": 1,
+       "s-628d1089a75a": 1,
+       "s-76e79f34ce14": 1,
+       "s-9ed3d693c69e": 1,
+       "s-f52419c599b1": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:064a7d792ef04c7a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341615.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-584f87a6e6ff",
+    "r-76437c462918",
+    "s-83e89144cb27"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-535c522dd09b": 1,
+       "s-699ae47ec3ee": 1,
+       "s-83e89144cb27": -4,
+       "s-f35978b781b0": 1,
+       "s-f6de5ed82b34": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b314912defe7a201",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789339075.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-38a0bb3be0f1",
+    "r-9a7d98cae503",
+    "s-092216a692db",
+    "s-4630b8adac76",
+    "s-79b0a318fd82"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-092216a692db": -3,
+       "s-1709fc2250c8": 1,
+       "s-4630b8adac76": -2,
+       "s-56fee8dcaf96": 3,
+       "s-79b0a318fd82": -4,
+       "s-c40daa50e69c": 3,
+       "s-cbfd41611a09": 1,
+       "s-f35978b781b0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c3c25a33a1070d75",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980610.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "o-0c534ec233e5",
+    "s-2cc172cfb276",
+    "s-43dba42d9c9b",
+    "s-a58bb909c4eb",
+    "s-f8968b74104d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0c534ec233e5": -1,
+       "o-ab45356f01bb": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-09d5ee757f1f": 3,
+       "s-2cc172cfb276": -1,
+       "s-3a111d158a31": 1,
+       "s-3bc4dcee0111": 1,
+       "s-3d1f5132ef42": 4,
+       "s-43dba42d9c9b": -5,
+       "s-a58bb909c4eb": -2,
+       "s-bdef55880e16": 1,
+       "s-f8968b74104d": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0e3ac932bb1d8231",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787888584.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "h:27736e92e6e1",
+    "o-8d8ae223d83e",
+    "r-41c555a1df1e",
+    "s-ce89d202fa83",
+    "s-d9af82ba3853"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2c3bf6e39430": 1,
+       "o-8d8ae223d83e": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-201e63869049": 2,
+       "s-afa963ca3cc0": 2,
+       "s-ce89d202fa83": -2,
+       "s-d9af82ba3853": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:fb63687fef6853f0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787731190.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-4f8ec49e308e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1d84784f5ca3": 1,
+       "s-4f8ec49e308e": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:fc8a275d57fdda5b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784175355.0,
+   "n_flipped_items": 25,
+   "n_lid_biting_flips": 25,
+   "lid_biting_items": [
+    "o-4d24b4",
+    "o-768300",
+    "r-17e845",
+    "r-271a32",
+    "r-2cf3c8",
+    "r-376a82",
+    "r-582a3f",
+    "r-63650f",
+    "r-694c83",
+    "r-6efedb",
+    "r-822dcd",
+    "r-9363f6",
+    "r-afff29",
+    "r-ce2752",
+    "r-d4c3d5",
+    "r-d7dbf0",
+    "s-3c3b98",
+    "s-3dc743",
+    "s-50b400",
+    "s-92a6b4",
+    "s-ae9b47",
+    "s-bca5b2",
+    "s-c76fc7",
+    "u-22e44e",
+    "u-7301f8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 32,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-1a8dba": 1,
+       "o-326f43": 2,
+       "o-46560b": 1,
+       "o-4d24b4": -6,
+       "o-768300": -7,
+       "o-7a5dad": 2,
+       "o-80e544": 1,
+       "o-ce0b06": 1,
+       "o-dfd23e": 1,
+       "o-eff95f": 2,
+       "o-f0f244": 2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 16,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-17741d": 2,
+       "s-3c3b98": -3,
+       "s-3dc743": -9,
+       "s-50b400": -4,
+       "s-6ebaa7": 4,
+       "s-84ba0b": 5,
+       "s-8620dc": 1,
+       "s-922595": 2,
+       "s-9a78b2": 2,
+       "s-a5c49a": 5,
+       "s-ab38bb": 6,
+       "s-ae9b47": -10,
+       "s-bca5b2": -4,
+       "s-c42c6c": 2,
+       "s-c76fc7": -1,
+       "s-d29e01": 2
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-22e44e": -1,
+       "u-24047d": 1,
+       "u-558f3a": 2,
+       "u-7301f8": -3,
+       "u-f66894": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:fc8a275d57fdda5b",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1786680955.0,
+   "n_flipped_items": 25,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-4d24b4",
+    "o-768300"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-1a8dba": 1,
+       "o-4d24b4": -2,
+       "o-768300": -5,
+       "o-7a5dad": 1,
+       "o-80e544": 1,
+       "o-ce0b06": 1,
+       "o-dfd23e": 1,
+       "o-eff95f": 1,
+       "o-f0f244": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:dee8fa511dcf986a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788128801.0,
+   "n_flipped_items": 15,
+   "n_lid_biting_flips": 11,
+   "lid_biting_items": [
+    "o-453b5d95b88e",
+    "r-0f086fe5c010",
+    "r-331326c75def",
+    "r-88059dfbd588",
+    "r-997f8f02f3cb",
+    "r-b67485a18295",
+    "s-0b48ef1cb43e",
+    "s-899ade68a15f",
+    "s-c66dcbba4e89",
+    "s-ce5ce485b0f0",
+    "s-e955a5f0fd3f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40,
+     "uncertainties": 18,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 40,
+     "uncertainties": 18,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 27,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0ecf82cb8f13": 1,
+       "o-453b5d95b88e": -2,
+       "o-e8a6960b453d": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 24,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-052ba0797573": 4,
+       "s-0b48ef1cb43e": -9,
+       "s-1aaa8c07ef26": 1,
+       "s-2836c5dbfe37": 1,
+       "s-2ced6861f01c": 1,
+       "s-36fe5942296e": 3,
+       "s-3d957fd57e2d": 4,
+       "s-4a642e727dad": 3,
+       "s-59224135f174": 2,
+       "s-69ecac1ede8d": 1,
+       "s-74545b358383": 3,
+       "s-7ab2c5c3c550": 4,
+       "s-7ead4ecaa6af": 1,
+       "s-801c4f6bc974": 4,
+       "s-899ade68a15f": -5,
+       "s-9bd86e95a948": 1,
+       "s-a7ee6f6e2658": 1,
+       "s-c66dcbba4e89": -10,
+       "s-ce5ce485b0f0": -8,
+       "s-d151f729e7c0": 1,
+       "s-d831217665a4": 3,
+       "s-e955a5f0fd3f": -9,
+       "s-eed2a5844d05": 2,
+       "s-f39ea24f609f": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c2167c7caca8ebb5",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785960012.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "h:88ec9ba7d4f8",
+    "r-079cd2f13594",
+    "s-33c9eca870b0",
+    "s-44bea15d48e3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    },
+    "ungated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0426d41a4189": 1,
+       "s-17c8da86bb23": 1,
+       "s-33c9eca870b0": -2,
+       "s-44bea15d48e3": -1,
+       "s-844f06aef8bb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:563cff79a6b163e6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786774720.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-684deac31fed",
+    "r-adefff38636c",
+    "s-595568e69baa",
+    "s-87e9485d2ab7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3c0eaf620489": 2,
+       "s-595568e69baa": -6,
+       "s-62b9807c3d57": 2,
+       "s-726978e3ea4d": 1,
+       "s-82e4d653597a": 2,
+       "s-87e9485d2ab7": -5,
+       "s-abb895fbfbb8": 2,
+       "s-ed74f28e357f": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b741ffc646d7b816",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786691321.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-09c21907af19",
+    "r-38b92d2606b4",
+    "s-7c9f02c074eb",
+    "s-c01ed5543f1d",
+    "s-e767e986fb17",
+    "s-f92064d36d78",
+    "s-ffa146d02207"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40
+    },
+    "ungated": {
+     "beliefs": 40
+    }
+   },
+   "positions_changed": 22,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 22,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2f6e8d6d6ca9": 5,
+       "s-34d04bff18b5": 4,
+       "s-4a3e427ba574": 5,
+       "s-4ba477f11dc7": 4,
+       "s-5977c9a9db5e": 5,
+       "s-69702a7b7eab": 5,
+       "s-7c9f02c074eb": -14,
+       "s-882c1bdd124c": 5,
+       "s-8ecf8fc92a08": 1,
+       "s-9975af4e33e2": 1,
+       "s-9dbecff3a129": 5,
+       "s-ade14442f07e": 4,
+       "s-ae6464b10546": 5,
+       "s-c01ed5543f1d": -12,
+       "s-c3f3f9422351": 5,
+       "s-cf7860c6f9b8": 5,
+       "s-d2862b613d85": 5,
+       "s-e767e986fb17": -14,
+       "s-e816441e20ff": 5,
+       "s-e86ac5047019": 1,
+       "s-f92064d36d78": -14,
+       "s-ffa146d02207": -16
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9d39978ddd25dbe2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787802731.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-68cac233fb7d",
+    "s-8c81bb82ca15"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3f451d1a34cb": 2,
+       "s-68cac233fb7d": -1,
+       "s-8c81bb82ca15": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4bac98f4c1f61722",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788226542.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "o-8f20cc8abd02",
+    "r-13bf917d5096",
+    "r-1f22649ae343",
+    "r-961582eeea75",
+    "s-42a72a9e2b68",
+    "s-a0426f1276c1",
+    "s-e450ca545652",
+    "s-fac006c061d9",
+    "u-8fc28b26d292"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 24,
+     "uncertainties": 9
+    },
+    "ungated": {
+     "beliefs": 24,
+     "uncertainties": 9
+    }
+   },
+   "positions_changed": 25,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0d70a0faec82": 1,
+       "o-5c5f41a2c690": 1,
+       "o-8f20cc8abd02": -5,
+       "o-9aca4299a9fc": 1,
+       "o-bb09bc046fee": 1,
+       "o-ce7a425f9d29": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0aeb3fc503a6": 3,
+       "s-21279c24c69d": 2,
+       "s-42a72a9e2b68": -11,
+       "s-45561dac93e0": 3,
+       "s-6594c825b4c3": 2,
+       "s-9b81373f9e84": 3,
+       "s-a0426f1276c1": -3,
+       "s-a8cffa3b8675": 2,
+       "s-ab395a28fa44": 1,
+       "s-c5a56819ee9a": 1,
+       "s-c6f05449f3a9": 4,
+       "s-d96d60f5ef22": 2,
+       "s-e450ca545652": -6,
+       "s-e4cdb1e76574": 3,
+       "s-eb51bdae3031": 3,
+       "s-f6280aa1bb67": 2,
+       "s-fac006c061d9": -11
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-8fc28b26d292": -1,
+       "u-c1578ef88cc1": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e14eda7d171e8cf0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786562496.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-0d5fc1bf6aa9",
+    "r-3bbedef5cafd",
+    "r-ac80adb8ecc8",
+    "r-bd4e38b05528",
+    "s-65e8c18f4ac9",
+    "s-b1ec0eb426b5",
+    "s-c6c616fdc5b3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-036dcc47f9e4": 1,
+       "s-288a58118486": 2,
+       "s-292fc2d66cde": 3,
+       "s-65e8c18f4ac9": -4,
+       "s-85e2f6488321": 3,
+       "s-a527ebf16eb4": 3,
+       "s-b1ec0eb426b5": -4,
+       "s-c6c616fdc5b3": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1c53d3cf1e2de48d",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787888584.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "h:27736e92e6e1",
+    "o-8d8ae223d83e",
+    "r-41c555a1df1e",
+    "s-ce89d202fa83",
+    "s-d9af82ba3853"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2c3bf6e39430": 1,
+       "o-8d8ae223d83e": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-201e63869049": 2,
+       "s-afa963ca3cc0": 2,
+       "s-ce89d202fa83": -2,
+       "s-d9af82ba3853": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:5f666fd4c3afe475",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788126793.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-d85fe2b8abb0",
+    "s-4ef4f0bf8804",
+    "s-c65ef1638f19",
+    "s-f3ff4b52f452"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3379c0e36d6e": 3,
+       "s-43ef8115dc97": 3,
+       "s-4ef4f0bf8804": -6,
+       "s-5f14a2642360": 3,
+       "s-67543ed036ae": 3,
+       "s-7b919d0f115a": 3,
+       "s-b6b42a4409c6": 3,
+       "s-c65ef1638f19": -6,
+       "s-f3ff4b52f452": -6
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e4097758dbd5c8c1",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789163606.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-9ffbee5798e2",
+    "s-f5a66545e46f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 13
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 13
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-10a1241589cb": 1,
+       "s-49bdee52c240": 1,
+       "s-72c4ac7c61b8": 1,
+       "s-992c31c47599": 1,
+       "s-9f086aa4df71": 1,
+       "s-e98ee41cacad": 1,
+       "s-f5a66545e46f": -6
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a9fca548076a3feb",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788738183.0,
+   "n_flipped_items": 32,
+   "n_lid_biting_flips": 24,
+   "lid_biting_items": [
+    "r-05383bc237ec",
+    "r-659c3e1ad736",
+    "r-68ed04e46409",
+    "r-740d09e38b73",
+    "r-744ad8a7e32e",
+    "r-77bed82f42e1",
+    "r-7c7cc711d76a",
+    "r-8711d40f0a8f",
+    "r-991abd7eddca",
+    "r-b8d61526ecbe",
+    "r-ece2154ffc3f",
+    "r-f0d011f0cf0b",
+    "s-0ebf14df31bd",
+    "s-4e2ea3f7f26e",
+    "s-54c591dda7f0",
+    "s-68cc0f5bc2d3",
+    "s-87cf59f5ddfd",
+    "s-8bb737f3fc5c",
+    "s-92df778b5f26",
+    "s-ad1966907004",
+    "s-adc641707a9e",
+    "s-b4079f5a9872",
+    "s-e95495b6eaae",
+    "s-f792ee76b83d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 56,
+     "uncertainties": 21,
+     "decisions": 2
+    },
+    "ungated": {
+     "beliefs": 56,
+     "uncertainties": 21,
+     "decisions": 2
+    }
+   },
+   "positions_changed": 39,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 39,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0ebf14df31bd": -18,
+       "s-10236c7fa784": 11,
+       "s-12bd4319abe9": 7,
+       "s-1d596b280201": 9,
+       "s-258383cb3435": 11,
+       "s-363bedccbc09": 10,
+       "s-37f62fd03732": 7,
+       "s-384f000c89e6": 5,
+       "s-3a6220055085": 6,
+       "s-3e9a3840549a": 12,
+       "s-47a263e0668c": 1,
+       "s-4c6f3b2484cf": 5,
+       "s-4e2ea3f7f26e": -11,
+       "s-5012d55bff81": 7,
+       "s-54c591dda7f0": -12,
+       "s-5654ac5eed88": 5,
+       "s-6169ba5b4420": 6,
+       "s-681d85b90569": 6,
+       "s-68cc0f5bc2d3": -9,
+       "s-6f68de3ea13d": 7,
+       "s-7043053c7d72": 6,
+       "s-86fb2b72ca7f": 7,
+       "s-87cf59f5ddfd": -18,
+       "s-8bb737f3fc5c": -18,
+       "s-8d57bd08bdde": 6,
+       "s-92df778b5f26": -17,
+       "s-98c5c6598e59": 10,
+       "s-9aadccbf4e1e": 6,
+       "s-a8f631cf31bd": 7,
+       "s-ad1966907004": -17,
+       "s-adc641707a9e": -11,
+       "s-b4079f5a9872": -12,
+       "s-ba1f7c349db5": 7,
+       "s-d884706b10f5": 1,
+       "s-e704f3608059": 2,
+       "s-e95495b6eaae": -18,
+       "s-f792ee76b83d": -19,
+       "s-f7cb0da239c8": 6,
+       "s-f8022b92f5fa": 7
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:609019d90be81e5c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788246917.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-0511fdb5aa9e",
+    "r-27305c811587",
+    "r-6115e622fea8",
+    "r-f2dd9a43b0fc",
+    "s-d0e267ac9ce2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 15
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 15
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-16ed9cfa058d": 1,
+       "s-272f43dc4937": 1,
+       "s-3597c0d8ddd7": 1,
+       "s-445b1a77d717": 1,
+       "s-46dcfeb667bf": 1,
+       "s-4ea5ee488511": 1,
+       "s-c0bd50089442": 1,
+       "s-cf2cbb547fa9": 1,
+       "s-d0e267ac9ce2": -9,
+       "s-e1d805646990": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1cf833691062f575",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786323219.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-71210f26306a",
+    "r-af3e94156daa",
+    "s-0f5136d3bf42",
+    "s-4e278822421f",
+    "s-b26796275ac5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 29,
+     "uncertainties": 13
+    },
+    "ungated": {
+     "beliefs": 29,
+     "uncertainties": 13
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0f5136d3bf42": -5,
+       "s-4bdafe86f02d": 3,
+       "s-4ceb0cd2f1b1": 3,
+       "s-4e278822421f": -4,
+       "s-53ccc9a9a7ce": 2,
+       "s-6f3736d1c493": 1,
+       "s-78afd13558ef": 1,
+       "s-b26796275ac5": -8,
+       "s-c1d686f823da": 3,
+       "s-e193834c33b9": 1,
+       "s-ec826a951811": 2,
+       "s-ffa9b87904cd": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7d3b39948dbf35a7",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785399052.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "o-02fbc7",
+    "o-552494",
+    "o-5a1bf2",
+    "o-ecd6e7",
+    "r-0026d2",
+    "r-507507",
+    "r-521279",
+    "r-9f4bc7",
+    "r-bec885",
+    "s-f6cbf2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 12,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 18,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 13,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-02fbc7": -9,
+       "o-1e946b": 4,
+       "o-251534": 4,
+       "o-29cef2": 4,
+       "o-552494": -9,
+       "o-5a1bf2": -9,
+       "o-7dc360": 4,
+       "o-8c0397": 4,
+       "o-9f2e03": 4,
+       "o-ce8dda": 4,
+       "o-d376b9": 4,
+       "o-e68997": 4,
+       "o-ecd6e7": -9
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6036c6": 1,
+       "s-7585c1": 1,
+       "s-91de60": 1,
+       "s-f6cbf2": -4,
+       "s-fb1b10": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7d3b39948dbf35a7",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1787904652.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-02fbc7",
+    "o-552494",
+    "o-5a1bf2",
+    "o-ecd6e7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 12,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-02fbc7": -2,
+       "o-552494": -2,
+       "o-5a1bf2": -2,
+       "o-8c0397": 4,
+       "o-9f2e03": 4,
+       "o-ecd6e7": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7fb5eac3d02c15cb",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786062940.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "r-03fc47c08c7f",
+    "r-0ec10200d939",
+    "r-123e2fca6dfa",
+    "r-1bbf41467f00",
+    "r-8ffef3f71752",
+    "r-ec56d70c766b",
+    "s-403c667572aa",
+    "s-5d7f5bfb93b1",
+    "s-f3d17a821e40"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 11
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 11
+    }
+   },
+   "positions_changed": 15,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 15,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0375e0fd1a8b": 1,
+       "s-2a42dde71b54": 2,
+       "s-2b321cc70ff8": 1,
+       "s-400184dc4d43": 1,
+       "s-403c667572aa": -7,
+       "s-508912118d9b": 2,
+       "s-5d7f5bfb93b1": -7,
+       "s-7f21c3f55b6f": 3,
+       "s-83168a007e1e": 1,
+       "s-a38658296571": 2,
+       "s-a5fa7defc695": 2,
+       "s-adc919fdfbc5": 2,
+       "s-b37b64128caa": 2,
+       "s-e8530917874b": 1,
+       "s-f3d17a821e40": -6
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ca82a812408a8505",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785364098.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 11,
+   "lid_biting_items": [
+    "h:3b12ddf72b64",
+    "o-fcaa54",
+    "r-158a6e",
+    "r-2f9c0b",
+    "r-56a249",
+    "r-895ca6",
+    "r-f5da55",
+    "s-163485",
+    "s-60416b",
+    "s-7129bd",
+    "s-bbb887"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 2
+    },
+    "ungated": {
+     "beliefs": 2
+    }
+   },
+   "positions_changed": 15,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-40deea": 1,
+       "o-f7df21": 1,
+       "o-fcaa54": -2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-982a09"
+      ],
+      "only_ungated": [
+       "s-60416b"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-163485": -8,
+       "s-2a8d29": 2,
+       "s-34785b": 4,
+       "s-373190": 2,
+       "s-449b4a": 4,
+       "s-4a2f20": 2,
+       "s-60416b": -4,
+       "s-7129bd": -8,
+       "s-75aefc": 2,
+       "s-982a09": 4,
+       "s-bbb887": -4,
+       "s-e5085d": 4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6e1ccbc586597229",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785525157.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-058062",
+    "r-399ef0",
+    "r-8398ed",
+    "r-88b886",
+    "r-ecb68d",
+    "s-42fdb2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-090bbb": 1,
+       "s-42fdb2": -4,
+       "s-87e23c": 1,
+       "s-b846d7": 1,
+       "s-e8fc14": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:06c7b5e42db0171a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786673810.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "h:137d835f6ad1",
+    "o-9896d439ee20",
+    "r-787e35403437",
+    "r-b22836594baf",
+    "r-e9dacdbeeb8d",
+    "s-0f5d1d3f6d88",
+    "s-61805f9f1f97",
+    "s-d29fd17372eb"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 13,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 13,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-090017849a1d": 2,
+       "s-0c72f3991afa": 2,
+       "s-0f5d1d3f6d88": -2,
+       "s-1f4bda9373c2": 2,
+       "s-4005e638d404": 2,
+       "s-436436919bca": 1,
+       "s-4ccb183c0355": 2,
+       "s-5e6fff0cb580": 3,
+       "s-61805f9f1f97": -10,
+       "s-9fbe71854b5e": 2,
+       "s-c75ef13650d4": 2,
+       "s-d29fd17372eb": -9,
+       "s-e2b397d68209": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e81f3a37833785d2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784254014.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-80c119",
+    "r-f8f137",
+    "r-ff2539",
+    "s-6fdbbe"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-f8f137"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 12,
+     "decisions": 2
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 12,
+     "decisions": 2
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-300414": 1,
+       "s-44d0d9": 1,
+       "s-4d1f1f": 1,
+       "s-6fdbbe": -6,
+       "s-8e1e2f": 1,
+       "s-aa0424": 1,
+       "s-c072b4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:484cf054521d4398",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788076468.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-ac9059c8b7f0",
+    "s-78ac02e291a2",
+    "s-e734e4fd668f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-75924613f4c4",
+       "s-eef2ca774c29"
+      ],
+      "only_ungated": [
+       "s-78ac02e291a2",
+       "s-e734e4fd668f"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-585f2775e80f": 2,
+       "s-75924613f4c4": 2,
+       "s-78ac02e291a2": -3,
+       "s-e734e4fd668f": -3,
+       "s-eef2ca774c29": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ba8ce7659acd6301",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788648127.0,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "o-011bcba81af5",
+    "o-4ce40097f36c",
+    "r-8c3a22923576",
+    "r-e9717c58fa8d",
+    "s-7568ac5470c1",
+    "s-bb0a376778be",
+    "s-d1d5a95e8fe0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 29,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 29,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 23,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-011bcba81af5": -2,
+       "o-3e074f9737d2": 1,
+       "o-55fba15a1ce4": 1
+      }
+     }
+    },
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-4ce40097f36c": -2,
+       "o-9cd122f19243": 1,
+       "o-acfea78bf4a3": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-040d804934ea": 1,
+       "s-0751d7df2f9f": 2,
+       "s-0a6a0159862c": 1,
+       "s-3158b875cd4c": 2,
+       "s-374e1ab1f87b": 1,
+       "s-4d4cdd06e587": 2,
+       "s-7568ac5470c1": -7,
+       "s-89e2570111cc": 1,
+       "s-a133f017de62": 2,
+       "s-a5e1d284616e": 1,
+       "s-b27e81b9f718": 2,
+       "s-b61d74a8027e": 1,
+       "s-bb0a376778be": -7,
+       "s-c22718fc2939": 2,
+       "s-cad38ada2088": 2,
+       "s-d1d5a95e8fe0": -7,
+       "s-ea70876077a3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d68e829c26ffb2cd",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788123520.0,
+   "n_flipped_items": 22,
+   "n_lid_biting_flips": 21,
+   "lid_biting_items": [
+    "o-dd1caa16cd8a",
+    "o-f4019385e73b",
+    "r-46a85d1a24ef",
+    "r-4e52fb0a74b2",
+    "r-5daec414e0dc",
+    "r-5e4c2d16cd6c",
+    "r-63313854e9ec",
+    "r-6dc3a8c0fdcd",
+    "r-842a8df138ec",
+    "r-909ea94bbfe8",
+    "r-ad616bc70b9f",
+    "r-b718cddce271",
+    "r-b8566a08e1bf",
+    "r-d5792e2799e4",
+    "r-d6afcb1c2234",
+    "r-e5a0896265bd",
+    "r-ea53cfc150ff",
+    "r-ed106edfbe7a",
+    "s-39924fced401",
+    "s-9ba17f97f8d6",
+    "s-e323c8b33550"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17
+    },
+    "ungated": {
+     "beliefs": 18
+    }
+   },
+   "positions_changed": 14,
+   "cap_crossings": 7,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-bdb1ece5cdfc": 1,
+       "o-cdbf6b49844b": 2,
+       "o-dd1caa16cd8a": -1,
+       "o-f4019385e73b": -2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 7,
+      "only_gated": [
+       "s-248e07f0a51c",
+       "s-548e6bee80e3",
+       "s-b4ed1b2c7745",
+       "s-e8495edec4eb"
+      ],
+      "only_ungated": [
+       "s-39924fced401",
+       "s-9ba17f97f8d6",
+       "s-e323c8b33550"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-248e07f0a51c": 3,
+       "s-39924fced401": -7,
+       "s-4868cf19373c": 3,
+       "s-548e6bee80e3": 3,
+       "s-9ba17f97f8d6": -7,
+       "s-b4ed1b2c7745": 3,
+       "s-b68f7f87c02c": 3,
+       "s-bcc1ebb704c3": 3,
+       "s-e323c8b33550": -7,
+       "s-e8495edec4eb": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d68e829c26ffb2cd",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1790629120.0,
+   "n_flipped_items": 22,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-dd1caa16cd8a",
+    "o-f4019385e73b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 18
+    },
+    "ungated": {
+     "beliefs": 18
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-cdbf6b49844b": 1,
+       "o-f4019385e73b": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:41b349b94394e42c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788128801.0,
+   "n_flipped_items": 15,
+   "n_lid_biting_flips": 11,
+   "lid_biting_items": [
+    "o-453b5d95b88e",
+    "r-0f086fe5c010",
+    "r-331326c75def",
+    "r-88059dfbd588",
+    "r-997f8f02f3cb",
+    "r-b67485a18295",
+    "s-0b48ef1cb43e",
+    "s-899ade68a15f",
+    "s-c66dcbba4e89",
+    "s-ce5ce485b0f0",
+    "s-e955a5f0fd3f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40,
+     "uncertainties": 18,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 40,
+     "uncertainties": 18,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 27,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0ecf82cb8f13": 1,
+       "o-453b5d95b88e": -2,
+       "o-e8a6960b453d": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 24,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-052ba0797573": 4,
+       "s-0b48ef1cb43e": -9,
+       "s-1aaa8c07ef26": 1,
+       "s-2836c5dbfe37": 1,
+       "s-2ced6861f01c": 1,
+       "s-36fe5942296e": 3,
+       "s-3d957fd57e2d": 4,
+       "s-4a642e727dad": 3,
+       "s-59224135f174": 2,
+       "s-69ecac1ede8d": 1,
+       "s-74545b358383": 3,
+       "s-7ab2c5c3c550": 4,
+       "s-7ead4ecaa6af": 1,
+       "s-801c4f6bc974": 4,
+       "s-899ade68a15f": -5,
+       "s-9bd86e95a948": 1,
+       "s-a7ee6f6e2658": 1,
+       "s-c66dcbba4e89": -10,
+       "s-ce5ce485b0f0": -8,
+       "s-d151f729e7c0": 1,
+       "s-d831217665a4": 3,
+       "s-e955a5f0fd3f": -9,
+       "s-eed2a5844d05": 2,
+       "s-f39ea24f609f": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b47c0ee3557b8137",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789200384.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-349daf2f93c8",
+    "s-7c169ddc2c0c"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-349daf2f93c8"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12
+    },
+    "ungated": {
+     "beliefs": 12
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2ba68c2e921b": 2,
+       "s-349daf2f93c8": -3,
+       "s-7c169ddc2c0c": -3,
+       "s-80914032c356": 2,
+       "s-bf073bfb768e": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6f2bfd6b34c87935",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785545413.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-0990d5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12
+    },
+    "ungated": {
+     "beliefs": 12
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-d68758"
+      ],
+      "only_ungated": [
+       "s-0990d5"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0990d5": -3,
+       "s-bf11f7": 1,
+       "s-d68758": 1,
+       "s-d89438": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:38a590106619482c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789337680.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-8e3a6c0e74df"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 5,
+     "uncertainties": 1
+    },
+    "ungated": {
+     "beliefs": 5,
+     "uncertainties": 1
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2c2200e04628": 1,
+       "o-837632290379": 1,
+       "o-8e3a6c0e74df": -4,
+       "o-beb29261b342": 1,
+       "o-f71a52246f2e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:73feb6b308e58ecd",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783829596.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-136291",
+    "r-1b4bf3",
+    "s-9ad0da",
+    "s-bc1763"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-cd9c7f"
+      ],
+      "only_ungated": [
+       "s-bc1763"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-18cc49": 1,
+       "s-9ad0da": -1,
+       "s-a80529": 1,
+       "s-bc1763": -2,
+       "s-cd9c7f": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f2780dc32f0dc69b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788400113.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-83f3b474c3ba",
+    "s-f1577adcea4e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 18,
+     "uncertainties": 11
+    },
+    "ungated": {
+     "beliefs": 18,
+     "uncertainties": 11
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1bd6959af835": 1,
+       "s-25bde11db045": 1,
+       "s-7389f55f05fa": 2,
+       "s-83f3b474c3ba": -5,
+       "s-89c1623da4bb": 1,
+       "s-a94ee578bd5b": 2,
+       "s-f1577adcea4e": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ea0ec3626a47749c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784146977.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-f3f8bd",
+    "s-a99d14"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-d00b88": 1,
+       "o-f3f8bd": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-40cb1e"
+      ],
+      "only_ungated": [
+       "s-a99d14"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-40cb1e": 1,
+       "s-475aef": 1,
+       "s-57cc32": 1,
+       "s-a99d14": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0f4823c559e8fa0d",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788584727.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "o-96aa2f66efdd",
+    "r-3f0577237794",
+    "s-210dc1c98d97",
+    "s-5a413788b88b",
+    "s-c418af2c8b67"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 28
+    },
+    "ungated": {
+     "beliefs": 28
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-6acef1430ee2": 1,
+       "o-96aa2f66efdd": -2,
+       "o-f47fe992b3c8": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 14,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-871dc4424a43"
+      ],
+      "only_ungated": [
+       "s-c418af2c8b67"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0576bf56164c": 2,
+       "s-1430c1643b8d": 3,
+       "s-204f2c8ef725": 3,
+       "s-210dc1c98d97": -8,
+       "s-23fd05de8a8a": 1,
+       "s-5a413788b88b": -7,
+       "s-871dc4424a43": 2,
+       "s-8efd52fec375": 2,
+       "s-98074152d9e1": 3,
+       "s-a20774fdc1ae": 1,
+       "s-c418af2c8b67": -7,
+       "s-cf80ee8476ad": 2,
+       "s-d0fbea21f751": 2,
+       "s-e8a15242fcfb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:85e71258e3cabcb7",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788052576.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-793f24a35b16",
+    "s-1100e8c4d9b3",
+    "s-883859dccce6",
+    "s-b96736b77aae",
+    "s-fd35d08257de"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-9bf4affb9792"
+      ],
+      "only_ungated": [
+       "s-fd35d08257de"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1100e8c4d9b3": -3,
+       "s-883859dccce6": -3,
+       "s-9393e814a8e6": 4,
+       "s-9bf4affb9792": 4,
+       "s-b96736b77aae": -3,
+       "s-fbd12c8d3cae": 3,
+       "s-fd35d08257de": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:19db41e467a479d6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785959784.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-a0915b56d6af"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    },
+    "ungated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-600d17dc86d2": 1,
+       "s-695e8da106ee": 1,
+       "s-a0915b56d6af": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4c071e1c686dd563",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785717711.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-3847ef3cc03c",
+    "r-4a0ed1d3654e",
+    "r-f60408f5fd5a",
+    "s-f56d11b0d3bb"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25,
+     "uncertainties": 9
+    },
+    "ungated": {
+     "beliefs": 25,
+     "uncertainties": 9
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-50b2343d6fc2": 1,
+       "s-db57c8fde027": 1,
+       "s-ea318bb01c4d": 1,
+       "s-eec61deb6864": 1,
+       "s-f56d11b0d3bb": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:61d2214f1358cc3e",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784080962.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-fb41ef"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3f207f": 1,
+       "s-fb41ef": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1ec12da0f1637456",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786931871.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-678c7def8ecc",
+    "s-f940f0a60794"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 6
+    },
+    "ungated": {
+     "beliefs": 6
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-003921a30178": 1,
+       "s-54e154e7b785": 2,
+       "s-678c7def8ecc": -2,
+       "s-7c0d51c26aae": 2,
+       "s-f940f0a60794": -4,
+       "s-ffa9fbf35ccd": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:32335f04520f4226",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786001866.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 12,
+   "lid_biting_items": [
+    "r-3374a53925b0",
+    "r-58cc6220de9f",
+    "r-61f4eb441957",
+    "r-68d562079b18",
+    "r-696fbe37fcf7",
+    "r-baabcf125472",
+    "r-ce257f475373",
+    "r-e601637d261d",
+    "r-ed741fcd5b3d",
+    "s-05625105a3ef",
+    "s-4492dbd8e229",
+    "s-f951b6302730"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25,
+     "uncertainties": 15
+    },
+    "ungated": {
+     "beliefs": 25,
+     "uncertainties": 15
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-03094c4cebca": 3,
+       "s-05625105a3ef": -6,
+       "s-333210aaf013": 2,
+       "s-4492dbd8e229": -6,
+       "s-8b0735ddf5f9": 3,
+       "s-96b9f34e13d6": 3,
+       "s-a15984c682f3": 1,
+       "s-c832fe502882": 2,
+       "s-ec9744347596": 3,
+       "s-f951b6302730": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:40551333be63f550",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788083243.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-0ecf7ade9546",
+    "s-9f743c153b04"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 15
+    },
+    "ungated": {
+     "beliefs": 15
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-778acc24790a": 1,
+       "s-94112f9e57dc": 1,
+       "s-9f743c153b04": -3,
+       "s-ffa4a95d03df": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d5294777ab91c789",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788310580.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "h:34ffb994ce4e",
+    "o-9c7c45cc93fd",
+    "r-20a93bfd35d6",
+    "r-74f638a49387",
+    "s-6ffe8173ffcc",
+    "s-7e796f8c22be",
+    "s-c19bed4dd833"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 21,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 21,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-4f15449d866a": 1,
+       "o-9c7c45cc93fd": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5cb404b7ef84": 3,
+       "s-6ffe8173ffcc": -3,
+       "s-73e215c9954c": 2,
+       "s-7e796f8c22be": -4,
+       "s-c19bed4dd833": -2,
+       "s-c1afe3894169": 1,
+       "s-cd4ce8e5ff57": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f72213dad77a571f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789062373.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-659209edffa2",
+    "r-d2d2cdaab0d2",
+    "r-f713cd794fc6",
+    "s-4fe8183a7a77",
+    "s-8f87cf295e15",
+    "s-c861f8561115",
+    "s-d440e4fc1be8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 29,
+     "uncertainties": 14
+    },
+    "ungated": {
+     "beliefs": 29,
+     "uncertainties": 14
+    }
+   },
+   "positions_changed": 19,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 19,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2939e867a816": 1,
+       "s-477f2a1c2e2f": 1,
+       "s-493018b1d43b": 2,
+       "s-4fe8183a7a77": -6,
+       "s-5505be2e63fb": 2,
+       "s-5cf3d755f37a": 3,
+       "s-7dbcddcfa68e": 3,
+       "s-8f87cf295e15": -9,
+       "s-967d162e4ae1": 3,
+       "s-9fffb4fa8dc9": 2,
+       "s-a4c65a43ef0f": 4,
+       "s-abb4e73eb27d": 3,
+       "s-b5cd2b8003f2": 1,
+       "s-c861f8561115": -10,
+       "s-d440e4fc1be8": -9,
+       "s-daa70512551f": 2,
+       "s-e0d421fcbb49": 2,
+       "s-e51c8d008d87": 3,
+       "s-ff75940a71bc": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0121d753f09ff00b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784175876.0,
+   "n_flipped_items": 17,
+   "n_lid_biting_flips": 17,
+   "lid_biting_items": [
+    "r-106ddd",
+    "r-3e0b7c",
+    "r-3ff437",
+    "r-421157",
+    "r-5dff8f",
+    "r-77ecd7",
+    "r-9d25f7",
+    "r-bd9731",
+    "r-f8e883",
+    "r-fa940f",
+    "s-0412e1",
+    "s-041bab",
+    "s-45c500",
+    "s-5dcc2c",
+    "s-691239",
+    "s-804a1a",
+    "s-842b19"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 16,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 16,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0412e1": -4,
+       "s-041bab": -6,
+       "s-1f562b": 5,
+       "s-2a3f22": 5,
+       "s-36e033": 1,
+       "s-38ec2f": 7,
+       "s-45c500": -9,
+       "s-4f2c06": 3,
+       "s-5dcc2c": -7,
+       "s-6813bc": 7,
+       "s-691239": -6,
+       "s-7055b0": 7,
+       "s-804a1a": -4,
+       "s-842b19": -7,
+       "s-94ea4a": 1,
+       "s-e1bc2a": 7
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:bc376505d353218f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786586954.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-55a6a7fa5804",
+    "r-9908a4d8f042",
+    "s-1f154a0e9234",
+    "s-6df014aeaec5",
+    "s-79b195c0335c",
+    "s-be659c2f3456",
+    "s-f4f81774b5ee",
+    "u-5529db531f48"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 22,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 16,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 14,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1c31b23d30d7": 5,
+       "s-1f154a0e9234": -7,
+       "s-20f2c432d205": 5,
+       "s-34e78dd727fd": 5,
+       "s-4fb9f77066c3": 5,
+       "s-57141d2e0d49": 1,
+       "s-6df014aeaec5": -9,
+       "s-79b195c0335c": -7,
+       "s-79f2a40698ab": 5,
+       "s-7cb3b75ab015": 5,
+       "s-9ae68d5af3a7": 1,
+       "s-be659c2f3456": -7,
+       "s-ce87f508036c": 5,
+       "s-f4f81774b5ee": -7
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-2fa5385f9035": 1,
+       "u-5529db531f48": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:eab186fb203adf91",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786691321.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-09c21907af19",
+    "r-38b92d2606b4",
+    "s-7c9f02c074eb",
+    "s-c01ed5543f1d",
+    "s-e767e986fb17",
+    "s-f92064d36d78",
+    "s-ffa146d02207"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40
+    },
+    "ungated": {
+     "beliefs": 40
+    }
+   },
+   "positions_changed": 22,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 22,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2f6e8d6d6ca9": 5,
+       "s-34d04bff18b5": 4,
+       "s-4a3e427ba574": 5,
+       "s-4ba477f11dc7": 4,
+       "s-5977c9a9db5e": 5,
+       "s-69702a7b7eab": 5,
+       "s-7c9f02c074eb": -14,
+       "s-882c1bdd124c": 5,
+       "s-8ecf8fc92a08": 1,
+       "s-9975af4e33e2": 1,
+       "s-9dbecff3a129": 5,
+       "s-ade14442f07e": 4,
+       "s-ae6464b10546": 5,
+       "s-c01ed5543f1d": -12,
+       "s-c3f3f9422351": 5,
+       "s-cf7860c6f9b8": 5,
+       "s-d2862b613d85": 5,
+       "s-e767e986fb17": -14,
+       "s-e816441e20ff": 5,
+       "s-e86ac5047019": 1,
+       "s-f92064d36d78": -14,
+       "s-ffa146d02207": -16
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e971918bb53b535f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786637381.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-2217eb1cabe5",
+    "r-46f37eed72bf",
+    "s-1aea43ef7c60",
+    "s-5d3bcc365f95"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1aea43ef7c60": -1,
+       "s-46f50ec80167": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6dd3dc40301f2a62",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788250388.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-04fe20442c70",
+    "s-ae0ba2390fc8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-04fe20442c70": -1,
+       "s-787916be872e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7626db1480bb74a6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785890651.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "h:cab83d5e8456",
+    "r-8f198eb5aac1",
+    "r-a3088eef5b2c",
+    "r-b52710f63d11",
+    "s-24f6e552b6e0",
+    "s-be3935a84d32"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16,
+     "uncertainties": 17
+    },
+    "ungated": {
+     "beliefs": 16,
+     "uncertainties": 17
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-05a8fd7a72fc": 2,
+       "s-248e4f00e50b": 2,
+       "s-24f6e552b6e0": -5,
+       "s-2a06d9c602d0": 2,
+       "s-b0a81979858b": 2,
+       "s-be3935a84d32": -6,
+       "s-e3a6ef55ceb5": 2,
+       "s-f0d144551e54": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b60037f63d4d2d10",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785854721.0,
+   "n_flipped_items": 17,
+   "n_lid_biting_flips": 16,
+   "lid_biting_items": [
+    "o-080b0f5942af",
+    "o-8096031c3f26",
+    "o-e6c70acbd403",
+    "r-0b8fa37b7fd5",
+    "r-1a919505605e",
+    "r-4ecada3df843",
+    "r-7088496f67ad",
+    "r-b761e391626e",
+    "r-d33225c11375",
+    "r-ffedd10e0dc9",
+    "s-4429c6522419",
+    "s-935fd789dfbe",
+    "s-a3d381fc2fec",
+    "s-b11ad6839c36",
+    "s-b6d1eaeb6f7d",
+    "u-a6386b958e0c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 5
+    },
+    "ungated": {
+     "beliefs": 6
+    }
+   },
+   "positions_changed": 21,
+   "cap_crossings": 5,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-8096031c3f26": -1,
+       "o-a8781a9789d1": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 5,
+      "only_gated": [
+       "s-9931657a53da",
+       "s-a918f60529cd",
+       "s-f396b638e6e8"
+      ],
+      "only_ungated": [
+       "s-b11ad6839c36",
+       "s-b6d1eaeb6f7d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0a916645b559": 1,
+       "s-0b98f7a72c1c": 1,
+       "s-1b5bfebf7132": 4,
+       "s-4429c6522419": -11,
+       "s-47ca7bd8427b": 4,
+       "s-49a1d7f4b229": 2,
+       "s-688cabaa3a7a": 1,
+       "s-79e7aa10e443": 4,
+       "s-935fd789dfbe": -8,
+       "s-9931657a53da": 4,
+       "s-a3d381fc2fec": -1,
+       "s-a918f60529cd": 4,
+       "s-b11ad6839c36": -6,
+       "s-b6d1eaeb6f7d": -6,
+       "s-c873fc4616e1": 1,
+       "s-dd9d94b83291": 2,
+       "s-f396b638e6e8": 4
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-7f06b48f3e08": 1,
+       "u-a6386b958e0c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:faf4817eb7e0c681",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785462243.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "o-138d96",
+    "s-24d88de82f58",
+    "s-4bd044ed8544",
+    "s-526cc12d9141",
+    "s-571e15bc61c3",
+    "s-6ac375c86e3b",
+    "s-7f47d142adcc",
+    "s-da3d1825074d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25
+    },
+    "ungated": {
+     "beliefs": 26
+    }
+   },
+   "positions_changed": 18,
+   "cap_crossings": 7,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 18,
+     "cap_crossings": {
+      "count": 7,
+      "only_gated": [
+       "s-001cdb652452",
+       "s-272ade03e625",
+       "s-47bb42e5b221",
+       "s-4ca6bae2daa8"
+      ],
+      "only_ungated": [
+       "s-526cc12d9141",
+       "s-6ac375c86e3b",
+       "s-da3d1825074d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-001cdb652452": 5,
+       "s-10325891c711": 7,
+       "s-1126a7afe8ac": 1,
+       "s-24d88de82f58": -3,
+       "s-272ade03e625": 5,
+       "s-47bb42e5b221": 4,
+       "s-4bd044ed8544": -5,
+       "s-4ca6bae2daa8": 3,
+       "s-526cc12d9141": -9,
+       "s-54788c3c1f0a": 6,
+       "s-571e15bc61c3": -2,
+       "s-578aaf1eac04": 5,
+       "s-6792676f8e89": 3,
+       "s-6ac375c86e3b": -9,
+       "s-74ac2f372644": 1,
+       "s-7f47d142adcc": -6,
+       "s-a1fcd3f977d1": 3,
+       "s-da3d1825074d": -9
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:01b0860e52af23d0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785294295.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-158b02",
+    "r-56a249",
+    "r-63a25f",
+    "s-112a43",
+    "s-2ff2cf"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 6,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 6,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-10896a": 2,
+       "s-112a43": -4,
+       "s-2c04bf": 2,
+       "s-2ff2cf": -4,
+       "s-4ca99a": 2,
+       "s-bbd9ad": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ab33b227f4694464",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789267706.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-d646776404b6",
+    "r-3c20495cc2b0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-bfdb6091e962": 1,
+       "o-d646776404b6": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:14ea84addde861bf",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788134749.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "h:a3f808cc7638",
+    "o-117c9fbde39a",
+    "r-1aaeed2e621c",
+    "r-ef5dd162ce74",
+    "s-8e8f324731ee"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-117c9fbde39a": -1,
+       "o-bdb1ece5cdfc": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-4d23a20927ee": 1,
+       "s-6f0fdc81bfc7": 1,
+       "s-8e8f324731ee": -5,
+       "s-a45e7fd179d9": 1,
+       "s-a562a7caaddf": 1,
+       "s-a641a7cffec5": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6c944de14b794b6a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787902030.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-df18b9e3ca69",
+    "s-17d1884bbde6",
+    "s-9695c3b497c3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-17d1884bbde6": -4,
+       "s-3ff5402a819d": 1,
+       "s-77e4b19ef35c": 1,
+       "s-966cafec2687": 1,
+       "s-9695c3b497c3": -3,
+       "s-bf1a40d41495": 1,
+       "s-c996c1031860": 1,
+       "s-dd274e643f0b": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7bf8c617c4ce514b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785960012.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "h:88ec9ba7d4f8",
+    "r-079cd2f13594",
+    "s-33c9eca870b0",
+    "s-44bea15d48e3"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    },
+    "ungated": {
+     "beliefs": 7,
+     "uncertainties": 2
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0426d41a4189": 1,
+       "s-17c8da86bb23": 1,
+       "s-33c9eca870b0": -2,
+       "s-44bea15d48e3": -1,
+       "s-844f06aef8bb": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0fe46877aaf798b8",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784665888.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-f3e2cd",
+    "r-0fdae4",
+    "r-76198e",
+    "r-9dad17"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 11,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-00ac31": 1,
+       "o-36b14a": 1,
+       "o-c9331e": 1,
+       "o-f3e2cd": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:889034a7353ecbe6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786307222.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-3ef9363379ea",
+    "r-452204a91681",
+    "s-a999f8081db4",
+    "s-bff6469db071"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 25,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-09b75d6fad37": 2,
+       "s-3147cbc234ca": 2,
+       "s-35a6862dbd00": 2,
+       "s-3ae4b18e8945": 2,
+       "s-6a9d685962f1": 2,
+       "s-a0dae6703c34": 2,
+       "s-a999f8081db4": -8,
+       "s-b92dbdc5b34f": 2,
+       "s-bff6469db071": -8,
+       "s-c41a11a16d90": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b959d0877e5e81e7",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785976189.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-3e6c76d9cd78",
+    "r-ae60115866c1",
+    "r-c24b56d3f2eb",
+    "s-642a050020f9",
+    "u-266b74a2b77e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 17
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 17
+    }
+   },
+   "positions_changed": 13,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0aab3c6f6c8d": 1,
+       "s-33e30a0e0b6c": 1,
+       "s-5799ed7ab88e": 1,
+       "s-642a050020f9": -7,
+       "s-8d07f0cf6ed0": 1,
+       "s-8e0e13169257": 1,
+       "s-991c50c888fc": 1,
+       "s-ddf1fc9d09f9": 1
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-266b74a2b77e": -4,
+       "u-44dca5781ab9": 1,
+       "u-540f58a359cd": 1,
+       "u-67075ac0e8b1": 1,
+       "u-a372ac93b2a3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b71a02c92cfe8e87",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785564487.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-2a2660",
+    "s-d9909e"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-2a2660"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 1,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 1,
+      "only_gated": [
+       "s-9d8059"
+      ],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2a2660": -1,
+       "s-376139": 1,
+       "s-9d8059": 1,
+       "s-cfeb08": 1,
+       "s-d9909e": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0b9264ec0a84a36a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788927350.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-7d64069c5ad7",
+    "r-bebf28f6caec",
+    "s-09a3d965fe54"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 20,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-09a3d965fe54": -4,
+       "s-1bff2088b4da": 1,
+       "s-1df84ca52893": 1,
+       "s-7fc2f250c8fc": 1,
+       "s-ef5e47e54c2e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:12f6c952d974b1ea",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784098311.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-0dd476",
+    "r-1ca55e",
+    "r-5c9702",
+    "r-5f105e",
+    "s-3bdd4d",
+    "s-d2ea56"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4
+    },
+    "ungated": {
+     "beliefs": 5
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 3,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 3,
+      "only_gated": [
+       "s-75293a",
+       "s-e19254"
+      ],
+      "only_ungated": [
+       "s-3bdd4d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3bdd4d": -5,
+       "s-6bfef5": 1,
+       "s-75293a": 1,
+       "s-ab4076": 2,
+       "s-b90ead": 1,
+       "s-d2ea56": -2,
+       "s-e19254": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:5ef7679bf75b79b5",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788071595.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-40550787ea83",
+    "r-dc432d8571df",
+    "s-160eb44baf00",
+    "s-793c3ff5a582",
+    "s-ffb650794e86"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 1
+    },
+    "ungated": {
+     "beliefs": 1
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-160eb44baf00": -4,
+       "s-294ab0a5dcae": 3,
+       "s-411956b34f63": 3,
+       "s-43a670bf567b": 2,
+       "s-48ec7ba9ec72": 3,
+       "s-5d685c666af4": 3,
+       "s-793c3ff5a582": -7,
+       "s-d2b6f1f902e9": 2,
+       "s-f3986b037efe": 2,
+       "s-ffb650794e86": -7
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e14357fff744eaeb",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788481502.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-1e82dcb2d02f",
+    "s-8233cba79754"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 28,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 28,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1e82dcb2d02f": -7,
+       "s-2f23a2e9cc0f": 2,
+       "s-6c0e3e1163ea": 1,
+       "s-7d7c201c4010": 1,
+       "s-8233cba79754": -3,
+       "s-8e54cae0c836": 2,
+       "s-9e8c7314013d": 2,
+       "s-a2331c837db7": 1,
+       "s-ac0e0289feaa": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:25133316fd951cb0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788564863.0,
+   "n_flipped_items": 18,
+   "n_lid_biting_flips": 15,
+   "lid_biting_items": [
+    "h:02b8e176ef83",
+    "r-10d8d821d542",
+    "r-4108a5e6e4a9",
+    "r-425438801945",
+    "r-5fb51e382ec9",
+    "r-6de3b8174627",
+    "r-72a4e55fe201",
+    "r-7a3f832eba6f",
+    "r-97408824f6cc",
+    "r-b049f83519d8",
+    "s-3d68a47c52d4",
+    "s-7cc6a1fac645",
+    "s-bca3bafe81ec",
+    "s-c0104581ab17",
+    "s-e50839496e8c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 36
+    },
+    "ungated": {
+     "beliefs": 36
+    }
+   },
+   "positions_changed": 30,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 30,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-8896cd2db93e",
+       "s-914700638a17"
+      ],
+      "only_ungated": [
+       "s-7cc6a1fac645",
+       "s-c0104581ab17"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-04f76ca4ba99": 2,
+       "s-05626971c0a1": 2,
+       "s-09d8c4e7cb57": 4,
+       "s-0c397b235761": 1,
+       "s-1a6737df831b": 4,
+       "s-2af933ceb3f7": 3,
+       "s-34f9493761cc": 3,
+       "s-3d68a47c52d4": -8,
+       "s-40966405e9ae": 2,
+       "s-40c18c89fc55": 3,
+       "s-56cde32a8419": 1,
+       "s-576d2208dc1c": 1,
+       "s-63ac82ab42c0": 2,
+       "s-67db5cfe460c": 1,
+       "s-6ab4e1a9cffe": 1,
+       "s-6add76ad3fb4": 2,
+       "s-6d7acd77b54b": 2,
+       "s-7cc6a1fac645": -13,
+       "s-7ffa798d2925": 2,
+       "s-8896cd2db93e": 2,
+       "s-914700638a17": 2,
+       "s-937f374dd480": 2,
+       "s-9a25c2dd36ad": 4,
+       "s-9b1449c9a076": 1,
+       "s-a861cf2ba2c7": 1,
+       "s-bca3bafe81ec": -6,
+       "s-c0104581ab17": -12,
+       "s-c73712643db1": 1,
+       "s-d0af07117799": 2,
+       "s-e50839496e8c": -12
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2695e1584f0a0fa0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788407128.0,
+   "n_flipped_items": 19,
+   "n_lid_biting_flips": 16,
+   "lid_biting_items": [
+    "o-debe5e141c0b",
+    "r-072f483bb64a",
+    "r-0e3cd4ef4627",
+    "r-0e7362e4a737",
+    "r-2d412fd35364",
+    "r-32dd7abf62ae",
+    "r-606a75cef0c7",
+    "r-a024708cfb79",
+    "r-a8bce3f04ef4",
+    "r-b38a3fdd127b",
+    "r-bb81b219e204",
+    "r-c01ebf57c9af",
+    "r-d91d5d23806d",
+    "r-d93527d29467",
+    "s-64aed3360ee0",
+    "s-b16817e29047"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 58,
+     "uncertainties": 10,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 58,
+     "uncertainties": 10,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 22,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-075ba7dc0226": 1,
+       "o-debe5e141c0b": -1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 20,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1037e37b910e": 2,
+       "s-1da2f0d12d60": 1,
+       "s-2e412982e0e8": 2,
+       "s-31ffe832f41f": 2,
+       "s-3d0df5299527": 2,
+       "s-4a4a756063d7": 2,
+       "s-4e89bbdc29a0": 1,
+       "s-57bb428efb57": 2,
+       "s-64aed3360ee0": -15,
+       "s-66e719508316": 1,
+       "s-76fd9fbccbd6": 1,
+       "s-7c0a2bb295f2": 1,
+       "s-81f2de8bb451": 1,
+       "s-89e918a7ba5e": 1,
+       "s-a7a261609a86": 1,
+       "s-b16817e29047": -10,
+       "s-cab615cdb452": 1,
+       "s-e410e4a971f5": 1,
+       "s-e59b6d34aa3a": 1,
+       "s-eed4b498d666": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2695e1584f0a0fa0",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1790912728.0,
+   "n_flipped_items": 19,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-debe5e141c0b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 58,
+     "uncertainties": 10,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 58,
+     "uncertainties": 10,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-075ba7dc0226": 1,
+       "o-debe5e141c0b": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3b9763dc79500fef",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788739879.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-44423b0ab9b8",
+    "r-715a3175a186",
+    "r-a2133cc8f28f",
+    "r-a618ede96a4c",
+    "r-c356cd16a59f",
+    "r-f6227e270364",
+    "s-9e61a4e83657",
+    "s-b3383f736d09"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 28,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 28,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-01ef198440d2": 1,
+       "s-1471ff7e63ad": 2,
+       "s-1f5e9b71bc04": 1,
+       "s-2a80f4b1fa67": 1,
+       "s-32f097c75aa4": 2,
+       "s-633ec7d2cc37": 1,
+       "s-66d3f2ca51e0": 1,
+       "s-67221259a6fc": 1,
+       "s-9e61a4e83657": -8,
+       "s-b3383f736d09": -3,
+       "s-c79869b971c5": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2a5922fd6b7f1d90",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784819860.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "o-24b9ad",
+    "r-5bcea7",
+    "r-61ccfc",
+    "r-63a25f",
+    "s-875cde",
+    "s-c96fc6",
+    "s-ea4ff9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 1
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 1
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5aa07c": 3,
+       "s-7e7d78": 2,
+       "s-875cde": -4,
+       "s-8937b6": 3,
+       "s-9222f2": 1,
+       "s-c96fc6": -2,
+       "s-ea4ff9": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ae399d959bb996fe",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784760234.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-01e245",
+    "r-ac3e1e",
+    "s-d7aff5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-190607": 1,
+       "s-30e0bc": 1,
+       "s-556ddd": 1,
+       "s-6c3449": 1,
+       "s-8876d2": 1,
+       "s-99c2b8": 1,
+       "s-ce9364": 1,
+       "s-d7aff5": -8,
+       "s-f3a2b4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:948b3d322f056dbf",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785481472.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-1d0ea7",
+    "r-fe631b",
+    "s-4ec848",
+    "s-f79b23"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 15
+    },
+    "ungated": {
+     "beliefs": 15
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-1e1ce4"
+      ],
+      "only_ungated": [
+       "s-f79b23"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-17084b": 1,
+       "s-1e1ce4": 1,
+       "s-4ec848": -1,
+       "s-5b25b0": 1,
+       "s-6af724": 1,
+       "s-914bfc": 1,
+       "s-dc3551": 1,
+       "s-f79b23": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:148f45c9ebd0f805",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786268214.0,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "r-36e6756c1a73",
+    "r-713869f95a7d",
+    "r-9dddc64be06e",
+    "r-d16607634836",
+    "r-edd87b9b8c80",
+    "r-f47157f172f3",
+    "r-f67bf89339dd",
+    "s-971991d385b3",
+    "s-982eb58ae089",
+    "s-ea4b901bd333"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 10
+    },
+    "ungated": {
+     "beliefs": 11
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 3,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 3,
+      "only_gated": [
+       "s-583abd66e538",
+       "s-d94018b7174e"
+      ],
+      "only_ungated": [
+       "s-982eb58ae089"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-15d3c01012fb": 2,
+       "s-583abd66e538": 3,
+       "s-8a0a1e976954": 2,
+       "s-971991d385b3": -3,
+       "s-982eb58ae089": -5,
+       "s-d71e2d8faec9": 1,
+       "s-d94018b7174e": 3,
+       "s-ea4b901bd333": -6,
+       "s-f1d1921f3bfd": 2,
+       "s-f604bd294da9": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f05732c4749d1f27",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788723902.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-68ba23f32f51",
+    "s-21e1538bdb20",
+    "s-49c1ebadb82e",
+    "s-8e9daaf7db70",
+    "s-97d7015ff8c0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 32,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 32,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 26,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 26,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-02cdabb18f45": 3,
+       "s-044d85b80f49": 4,
+       "s-209567ebbabc": 4,
+       "s-2133b94f171f": 4,
+       "s-21e1538bdb20": -13,
+       "s-49c1ebadb82e": -22,
+       "s-67e9a32f6f25": 4,
+       "s-756328e32f05": 4,
+       "s-7a65495efb76": 3,
+       "s-82e5c7083c89": 4,
+       "s-875358f28d97": 2,
+       "s-87e7f6baa099": 4,
+       "s-8e9daaf7db70": -18,
+       "s-967269d1ebfc": 3,
+       "s-97d7015ff8c0": -22,
+       "s-a83c0f03e9ec": 4,
+       "s-d662ef2b020b": 3,
+       "s-d9158ef4aec2": 4,
+       "s-dead0c6de006": 4,
+       "s-dfb0c92d863e": 2,
+       "s-e076329d6c62": 4,
+       "s-e2b0f89c15c8": 3,
+       "s-e76ea20d6d2a": 2,
+       "s-e96b9c4b7e02": 4,
+       "s-ec2db2e4795e": 2,
+       "s-f4922cc3e418": 4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:8ebb7432ffc2ff8e",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784055579.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-5f1e61",
+    "r-83bb25",
+    "r-e73d32",
+    "s-1a04a5",
+    "s-64ce88"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 8,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 8,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1a04a5": -1,
+       "s-35138f": 1,
+       "s-64ce88": -3,
+       "s-84e426": 2,
+       "s-f35160": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3762c6dde28fc46b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789333699.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-3253a18a2154",
+    "r-aec21dbf131c",
+    "s-32dd7b72385e",
+    "s-bf358665add2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-8dbedbaaca57",
+       "s-b234b013d733"
+      ],
+      "only_ungated": [
+       "s-32dd7b72385e",
+       "s-bf358665add2"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-32dd7b72385e": -7,
+       "s-352a468d0fa1": 2,
+       "s-54eacaeab14f": 1,
+       "s-5af25ca91a9b": 2,
+       "s-635a8a71a8e6": 1,
+       "s-76371b591f6e": 2,
+       "s-8dbedbaaca57": 2,
+       "s-b234b013d733": 2,
+       "s-bf358665add2": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9be6c40e054e583f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789166553.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "o-795b9fa3c201",
+    "o-902974e60f6d",
+    "r-7660e5cc4f29",
+    "r-b4f8fe02495c",
+    "r-f43dac8f856c",
+    "r-f74001c238d0",
+    "s-07e5dfd011d1",
+    "s-21691e24a399",
+    "s-464cdff25355",
+    "s-5d5cbfd21165"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 24,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 24,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-663c288d0ed9": 1,
+       "o-795b9fa3c201": -3,
+       "o-85f43c200743": 2,
+       "o-902974e60f6d": -4,
+       "o-bfdb6091e962": 2,
+       "o-e506e8a1862f": 2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-07e5dfd011d1": -6,
+       "s-21691e24a399": -6,
+       "s-3bbc4a0a32cd": 4,
+       "s-464cdff25355": -4,
+       "s-5d5cbfd21165": -6,
+       "s-671533dd714e": 4,
+       "s-6c0b21768828": 1,
+       "s-96935478845e": 3,
+       "s-c60d96325b99": 4,
+       "s-ccfaff8d842c": 3,
+       "s-f0ca39c3a7ed": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9be6c40e054e583f",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1791672153.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-902974e60f6d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 24,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 24,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-663c288d0ed9": 1,
+       "o-902974e60f6d": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:bb7df1a1e9d61dac",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783722166.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-120729",
+    "r-54d71a",
+    "r-59698e",
+    "r-782e80",
+    "r-c7527c",
+    "r-e573de",
+    "s-06e6d1",
+    "s-7e5281"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-c7527c"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 3,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 3,
+      "only_gated": [
+       "s-00e999",
+       "s-debb05"
+      ],
+      "only_ungated": [
+       "s-7e5281"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-00e999": 2,
+       "s-06e6d1": -2,
+       "s-7e5281": -2,
+       "s-debb05": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:75cadf73293d9847",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788679472.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-0091a7472260",
+    "r-1ef02e7d8820",
+    "r-81b835737116",
+    "r-9adc3b808cfa",
+    "r-d988bc242f4e",
+    "s-7629fc740147"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25
+    },
+    "ungated": {
+     "beliefs": 25
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1e7dffd917d9": 1,
+       "s-451e9d75381a": 1,
+       "s-7629fc740147": -4,
+       "s-87128abd5cbc": 1,
+       "s-a79418bbc6b3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:22618eff4571b813",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789291557.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-d0246fc247f9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 5
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-d0246fc247f9": -2,
+       "s-d98d6f640ded": 1,
+       "s-f86a74f5f1b3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7b14a8b8ff2b8643",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789080503.0,
+   "n_flipped_items": 28,
+   "n_lid_biting_flips": 25,
+   "lid_biting_items": [
+    "o-83beda4c7e72",
+    "o-ba61ffa8aa5c",
+    "r-0049f457be9f",
+    "r-06898a0235b6",
+    "r-194f6342d161",
+    "r-1f52b722a25a",
+    "r-3a82b1722d34",
+    "r-5126d3cabdfa",
+    "r-612477569400",
+    "r-8ac11aaaea9e",
+    "r-8add38270397",
+    "r-a8b1c4567966",
+    "r-ad98fb4473f4",
+    "r-b5b34bb8fdd9",
+    "r-c2bc16bd5831",
+    "r-ccc267c16468",
+    "r-cef5381111f3",
+    "r-d4a5a1e021c9",
+    "r-e2059b300fe1",
+    "r-ec800e60a387",
+    "r-f5a956f647a4",
+    "s-034c23db060b",
+    "s-17beddf54a6d",
+    "s-47fd3cafe4f9",
+    "s-ca02253e8b1a"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-ca02253e8b1a"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 46,
+     "uncertainties": 13
+    },
+    "ungated": {
+     "beliefs": 46,
+     "uncertainties": 13
+    }
+   },
+   "positions_changed": 20,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-83beda4c7e72": -1,
+       "o-ba61ffa8aa5c": -1,
+       "o-d7cf084041bb": 2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-034c23db060b": -10,
+       "s-16843eec78f5": 4,
+       "s-17beddf54a6d": -9,
+       "s-451e48ef828f": 1,
+       "s-47fd3cafe4f9": -9,
+       "s-4d0bc7d6bb34": 1,
+       "s-5a310c77f163": 2,
+       "s-5c995d09b8c5": 4,
+       "s-5e9c62506ade": 2,
+       "s-81950091cfd1": 4,
+       "s-890d17fc9e3b": 4,
+       "s-9774a54e092f": 3,
+       "s-a8e8aa179739": 4,
+       "s-b969479ba06f": 1,
+       "s-ca02253e8b1a": -9,
+       "s-ca35fb504164": 4,
+       "s-f40d4855e804": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7b14a8b8ff2b8643",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1791586103.0,
+   "n_flipped_items": 28,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-83beda4c7e72",
+    "o-ba61ffa8aa5c"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-ca02253e8b1a"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 46,
+     "uncertainties": 12
+    },
+    "ungated": {
+     "beliefs": 46,
+     "uncertainties": 12
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-83beda4c7e72": -1,
+       "o-ba61ffa8aa5c": -1,
+       "o-d7cf084041bb": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:397b32516e939738",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788115305.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-62aa976fae62"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 2
+    },
+    "ungated": {
+     "beliefs": 2
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-01838612a5fe": 1,
+       "s-2eecc902d12e": 1,
+       "s-62aa976fae62": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7e85ef710e9af1a7",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784175355.0,
+   "n_flipped_items": 25,
+   "n_lid_biting_flips": 25,
+   "lid_biting_items": [
+    "o-4d24b4",
+    "o-768300",
+    "r-17e845",
+    "r-271a32",
+    "r-2cf3c8",
+    "r-376a82",
+    "r-582a3f",
+    "r-63650f",
+    "r-694c83",
+    "r-6efedb",
+    "r-822dcd",
+    "r-9363f6",
+    "r-afff29",
+    "r-ce2752",
+    "r-d4c3d5",
+    "r-d7dbf0",
+    "s-3c3b98",
+    "s-3dc743",
+    "s-50b400",
+    "s-92a6b4",
+    "s-ae9b47",
+    "s-bca5b2",
+    "s-c76fc7",
+    "u-22e44e",
+    "u-7301f8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 32,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-1a8dba": 1,
+       "o-326f43": 2,
+       "o-46560b": 1,
+       "o-4d24b4": -6,
+       "o-768300": -7,
+       "o-7a5dad": 2,
+       "o-80e544": 1,
+       "o-ce0b06": 1,
+       "o-dfd23e": 1,
+       "o-eff95f": 2,
+       "o-f0f244": 2
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 16,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-17741d": 2,
+       "s-3c3b98": -3,
+       "s-3dc743": -9,
+       "s-50b400": -4,
+       "s-6ebaa7": 4,
+       "s-84ba0b": 5,
+       "s-8620dc": 1,
+       "s-922595": 2,
+       "s-9a78b2": 2,
+       "s-a5c49a": 5,
+       "s-ab38bb": 6,
+       "s-ae9b47": -10,
+       "s-bca5b2": -4,
+       "s-c42c6c": 2,
+       "s-c76fc7": -1,
+       "s-d29e01": 2
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-22e44e": -1,
+       "u-24047d": 1,
+       "u-558f3a": 2,
+       "u-7301f8": -3,
+       "u-f66894": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7e85ef710e9af1a7",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1786680955.0,
+   "n_flipped_items": 25,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-4d24b4",
+    "o-768300"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 4
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-1a8dba": 1,
+       "o-4d24b4": -2,
+       "o-768300": -5,
+       "o-7a5dad": 1,
+       "o-80e544": 1,
+       "o-ce0b06": 1,
+       "o-dfd23e": 1,
+       "o-eff95f": 1,
+       "o-f0f244": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:50978242649c7b56",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784175844.0,
+   "n_flipped_items": 17,
+   "n_lid_biting_flips": 13,
+   "lid_biting_items": [
+    "o-dd3e23",
+    "r-4234f2",
+    "r-46c96d",
+    "r-6057c8",
+    "r-8cb08d",
+    "s-199adb",
+    "s-453dac",
+    "s-67e0e2",
+    "s-7b91d5",
+    "s-83c5fa",
+    "s-d3b43b",
+    "s-eb0889",
+    "s-ee2b12"
+   ],
+   "n_truncation_exempting_flips": 2,
+   "truncation_exempting_items": [
+    "s-83c5fa",
+    "s-d3b43b"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 14,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 21,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-43774e": 1,
+       "o-49088f": 1,
+       "o-4b6c03": 1,
+       "o-4d4e1c": 1,
+       "o-d602c7": 1,
+       "o-dca808": 1,
+       "o-dd3e23": -7,
+       "o-eabca6": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 13,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-199adb": -4,
+       "s-29ec71": 2,
+       "s-453dac": -1,
+       "s-67e0e2": -3,
+       "s-7b91d5": -4,
+       "s-83c5fa": -4,
+       "s-a5d98e": 6,
+       "s-c5d25d": 5,
+       "s-d3b43b": -4,
+       "s-e69910": 4,
+       "s-eadc14": 6,
+       "s-eb0889": -2,
+       "s-ee2b12": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:488363a3ea39a1a8",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786323061.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-276c4595a45b",
+    "r-452fdd892fbe",
+    "r-83dcbba776e8",
+    "r-841e87c140a6",
+    "r-d121ea19ae39",
+    "s-e1ea039fd9f7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-18766c116d18": 1,
+       "s-3d5529194026": 1,
+       "s-9ddd7b71324e": 1,
+       "s-da2f6b53f2b8": 1,
+       "s-e1ea039fd9f7": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:85d1d29e3f80974e",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787887658.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-23af7c2adea8"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-13987a06cb07": 1,
+       "s-23af7c2adea8": -4,
+       "s-463ec64a322f": 1,
+       "s-a699669e1a99": 1,
+       "s-aa28fe7fd459": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a8fc7398410dc3b5",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784334384.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "r-05f2af2c3824",
+    "r-147d98ac9d6f",
+    "r-1899432a93d1",
+    "r-21ac6e63f8cf",
+    "r-c7a4b88e8f16",
+    "r-fbcdcfdea531",
+    "s-0ac9011074e5",
+    "s-0cbe3f64bfaf",
+    "s-a60cf09c6422",
+    "s-f065e8f2e7b5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25,
+     "uncertainties": 12,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 25,
+     "uncertainties": 12,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 15,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 15,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-01592cda58fe": 2,
+       "s-0ac9011074e5": -4,
+       "s-0cbe3f64bfaf": -7,
+       "s-68090a7cffcc": 2,
+       "s-720c9b6564f0": 1,
+       "s-7e0a3d4b4d67": 2,
+       "s-876c04e0ad19": 1,
+       "s-9ebfa615bd5a": 3,
+       "s-a60cf09c6422": -3,
+       "s-b5006cb48ee6": 1,
+       "s-bc5ed9cfbbf6": 2,
+       "s-c35748c97410": 2,
+       "s-d59e007e5d56": 1,
+       "s-eb07220a7164": 1,
+       "s-f065e8f2e7b5": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1a1cfa09a22526ad",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787977375.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-058ded33c833",
+    "r-2d7cc0f382c9",
+    "r-685a170c6fd5",
+    "r-cde8b4415900",
+    "r-d539a0d76223",
+    "s-546bf907ceda",
+    "s-c91bbce15518",
+    "s-d16b053bc866"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 27
+    },
+    "ungated": {
+     "beliefs": 27
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-078262337eb8": 3,
+       "s-2fbf07c3e21c": 3,
+       "s-506152489b2a": 3,
+       "s-546bf907ceda": -4,
+       "s-c4213595657b": 1,
+       "s-c91bbce15518": -5,
+       "s-d16b053bc866": -4,
+       "s-e4984a5e14a1": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4659264f30f63a59",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787795964.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-60aab3755fe3",
+    "s-345088f42d6c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14
+    },
+    "ungated": {
+     "beliefs": 14
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2079b2556cc0": 1,
+       "s-345088f42d6c": -4,
+       "s-53824073b148": 1,
+       "s-7e923da92102": 1,
+       "s-b8618173fcbe": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cf588f440afa6fe2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786592238.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-ad5991c7c565",
+    "s-1794685f8714"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1794685f8714": -5,
+       "s-85af95d36859": 1,
+       "s-861952d98dd3": 1,
+       "s-8d955adb3f80": 1,
+       "s-aed8a2b77fa7": 1,
+       "s-c9622f7b9bef": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cd33a4e6a4ddf2d2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980578.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-2194d0120086",
+    "r-2681b0a26be1",
+    "r-f5bfff1ef08d",
+    "s-6ea52280a91a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 18,
+     "uncertainties": 9
+    },
+    "ungated": {
+     "beliefs": 18,
+     "uncertainties": 9
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-2194d0120086": -2,
+       "o-761fedd08eca": 1,
+       "o-a92e0e64c9aa": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-00dfa4224242": 1,
+       "s-04de31ed6437": 1,
+       "s-6ea52280a91a": -4,
+       "s-724c089eef9b": 1,
+       "s-adc6adef5335": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:be7ee57753e084fc",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786841474.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-ad40e25ef49f",
+    "s-8406d4b767ca"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 8
+    },
+    "ungated": {
+     "beliefs": 8
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-e4ebb8fafa5d"
+      ],
+      "only_ungated": [
+       "s-8406d4b767ca"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0d89ceba5f8a": 1,
+       "s-35b222df2dd4": 1,
+       "s-68f421697091": 1,
+       "s-8406d4b767ca": -5,
+       "s-e36275a65c75": 1,
+       "s-e4ebb8fafa5d": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:de827b6d42e1ca88",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789260919.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-691764ddd72c",
+    "s-f52419c599b1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0fa50a112a7c": 1,
+       "s-628d1089a75a": 1,
+       "s-76e79f34ce14": 1,
+       "s-9ed3d693c69e": 1,
+       "s-f52419c599b1": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e8b0e34035c4b6a9",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786516872.0,
+   "n_flipped_items": 16,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "o-530373dcdc8c",
+    "r-1e2d5464b335",
+    "r-284c4dff80c3",
+    "r-3727da0e8ab9",
+    "r-5769b5bf377c",
+    "r-a79620bbb62d",
+    "s-6b48f506bc8d",
+    "s-82b69c3c7b60",
+    "s-d9830ab1c248"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 27,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 27,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 14,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-11a9b816e931": 1,
+       "o-530373dcdc8c": -2,
+       "o-973322c3226f": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-31ea32e9060b": 3,
+       "s-4f8e61500a55": 3,
+       "s-6b48f506bc8d": -7,
+       "s-82b69c3c7b60": -8,
+       "s-8d5832ca052c": 1,
+       "s-a4edbe08e9b2": 3,
+       "s-ba783d6464ed": 3,
+       "s-bf79549021f0": 3,
+       "s-c1b6b2a7ad05": 3,
+       "s-ce6c6e42768a": 3,
+       "s-d9830ab1c248": -7
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9440a45d5d900594",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783745748.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-120729",
+    "r-5f6ff1",
+    "r-782e80",
+    "s-85df72",
+    "u-58ea51"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-120729"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 13,
+   "cap_crossings": 1,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-24311a": 1,
+       "s-7a2072": 1,
+       "s-85df72": -5,
+       "s-a04722": 1,
+       "s-c3d374": 1,
+       "s-e860ec": 1
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 1,
+      "only_gated": [
+       "u-fd0e74"
+      ],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-00e00c": 1,
+       "u-253f49": 1,
+       "u-4a151b": 1,
+       "u-58ea51": -6,
+       "u-5ca1f0": 1,
+       "u-8c249c": 1,
+       "u-fd0e74": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9440a45d5d900594",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1786251348.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 0,
+   "lid_biting_items": [],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-120729"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 4
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 5
+    }
+   },
+   "positions_changed": 0,
+   "cap_crossings": 1,
+   "differs": true,
+   "sections": {
+    "uncertainties": {
+     "positions_changed": 0,
+     "cap_crossings": {
+      "count": 1,
+      "only_gated": [
+       "u-8fad4a"
+      ],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": true,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {}
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6d444a237e2de0ca",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785468850.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 11,
+   "lid_biting_items": [
+    "h:81668a8db177",
+    "r-08246a",
+    "r-509e73",
+    "r-63cebf",
+    "r-7ca647",
+    "r-88e233",
+    "r-9ef30e",
+    "r-a4f3ee",
+    "r-ec6987",
+    "s-77451e",
+    "s-e7f89c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 17
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 1,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 1,
+      "only_gated": [
+       "s-375b4e"
+      ],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-307a5e": 1,
+       "s-375b4e": 1,
+       "s-5b7623": 1,
+       "s-61e53f": 1,
+       "s-77451e": -2,
+       "s-7eafce": 1,
+       "s-e7f89c": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:dbaa89943e5bc7df",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789200637.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-2fe905d594cd",
+    "r-c254c0abf12f",
+    "s-469438a9340c",
+    "s-e5c1b6f9e36c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 21,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 21,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0acb6c478fe5": 1,
+       "s-469438a9340c": -5,
+       "s-4909979a0791": 1,
+       "s-7395f90c3226": 1,
+       "s-7667f0e630bc": 1,
+       "s-7dcee8875fd7": 1,
+       "s-c98d11b1b6df": 1,
+       "s-e5c1b6f9e36c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d247350b588b4e5c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786152191.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-ebe9fd712ea7",
+    "r-f5697d477fe2",
+    "r-fa58452e5111",
+    "s-57701061433e",
+    "s-588d71ce8ac8",
+    "s-6fbd67e479c4",
+    "s-7e6988884e1e",
+    "s-9e6a1a292bc6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 27,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 27,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0e5367c64b04": 2,
+       "s-3c2dff2293db": 5,
+       "s-57701061433e": -5,
+       "s-588d71ce8ac8": -3,
+       "s-6fbd67e479c4": -3,
+       "s-7e6988884e1e": -5,
+       "s-872957e93fa5": 5,
+       "s-9e6a1a292bc6": -3,
+       "s-d90051066e59": 2,
+       "s-e63489cafd8f": 5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9873c00a5a0b9276",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784491301.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-0d9228"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 7,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0d9228": -1,
+       "s-b3e39f": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c87f22a9400f72a1",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786866054.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-53060de808e9",
+    "r-eae78150c4cc",
+    "s-137693d1b0ea",
+    "s-1c9dc0e50707",
+    "s-226f94fa3135",
+    "s-c7eb78c43d61",
+    "u-067c2777094f"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-137693d1b0ea"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 13,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-42ebe4a5a547",
+       "s-678c07412350",
+       "s-926a7048323f"
+      ],
+      "only_ungated": [
+       "s-226f94fa3135"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-137693d1b0ea": -7,
+       "s-154f99b8b609": 4,
+       "s-1c9dc0e50707": -7,
+       "s-226f94fa3135": -5,
+       "s-42ebe4a5a547": 4,
+       "s-678c07412350": 4,
+       "s-886b84c78fe0": 3,
+       "s-926a7048323f": 4,
+       "s-b21d7845db34": 3,
+       "s-c7eb78c43d61": -7,
+       "s-f8a2b2ddf8fc": 4
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-067c2777094f": -1,
+       "u-1bd88cec4a16": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1762ffbd0413abd1",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784244506.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "o-40e263",
+    "o-49ce33",
+    "o-81eb14",
+    "r-101643",
+    "s-4debe8",
+    "s-63cd61"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13,
+     "uncertainties": 11
+    },
+    "ungated": {
+     "beliefs": 13,
+     "uncertainties": 11
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-40e263": -1,
+       "o-49ce33": -1,
+       "o-81eb14": -1,
+       "o-da1220": 3
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-39e5a4": 2,
+       "s-4debe8": -3,
+       "s-63cd61": -3,
+       "s-cf6b7d": 2,
+       "s-d65481": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a0449a3a48988f82",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788723489.0,
+   "n_flipped_items": 20,
+   "n_lid_biting_flips": 19,
+   "lid_biting_items": [
+    "o-29ba0caf00d3",
+    "r-0069d1a525b6",
+    "r-05b8a287b22c",
+    "r-189298c5383d",
+    "r-2842bba4d93a",
+    "r-51e277464c34",
+    "r-586d2fdf007b",
+    "r-5b5fdf4c7bac",
+    "r-81bcd2e2ee8f",
+    "r-8f19d3ee79db",
+    "r-b38380790026",
+    "s-3cd5d35ca83d",
+    "s-719bd28afde1",
+    "s-8c1fd10b4cc1",
+    "s-8de00f0d46d8",
+    "s-911aacddef5a",
+    "s-b848681872d0",
+    "s-c60f8119d3d6",
+    "s-ea48f74b1729"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 32
+    },
+    "ungated": {
+     "beliefs": 32
+    }
+   },
+   "positions_changed": 23,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-29ba0caf00d3": -3,
+       "o-55fba15a1ce4": 1,
+       "o-cf107be88478": 1,
+       "o-f6db3a0dd241": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 19,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-15070c5b9c9f": 4,
+       "s-275b931e79b5": 6,
+       "s-3aa4950992c6": 2,
+       "s-3cd5d35ca83d": -3,
+       "s-5c46e8b9dd72": 5,
+       "s-67aba5d9ab04": 3,
+       "s-719bd28afde1": -4,
+       "s-8352a6248c8a": 1,
+       "s-8c1fd10b4cc1": -3,
+       "s-8ca07246e3c9": 2,
+       "s-8de00f0d46d8": -5,
+       "s-911aacddef5a": -2,
+       "s-923514f97262": 2,
+       "s-98103684108e": 6,
+       "s-a11e35a74bbf": 2,
+       "s-b848681872d0": -8,
+       "s-c60f8119d3d6": -9,
+       "s-e4ee695ae89f": 3,
+       "s-ea48f74b1729": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e5ba4b4d2a218edd",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787724613.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-2301bed4b134",
+    "r-3b2fe98c7c61",
+    "s-1c1e048c2d7d",
+    "s-de0f9e9daeda"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 9
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 9
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1c1e048c2d7d": -4,
+       "s-56f7857dd593": 2,
+       "s-587a3095f370": 2,
+       "s-601ff7f04547": 2,
+       "s-73228cd50a2f": 2,
+       "s-de0f9e9daeda": -4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e0e0309c8143315a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788073929.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "o-a25007f4c6e3",
+    "r-304a4ed4f0d4",
+    "r-3b021e7ba8c5",
+    "r-4f62fd1dff95",
+    "r-bf4ee92d41bb",
+    "s-15609a6f3c71",
+    "s-4db06d37106e",
+    "s-615b988a4f25",
+    "s-7ac48c95c8b3",
+    "s-a4b2a6e5733c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 23
+    },
+    "ungated": {
+     "beliefs": 23
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-936972dfead1"
+      ],
+      "only_ungated": [
+       "s-a4b2a6e5733c"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-06961db383db": 5,
+       "s-15609a6f3c71": -2,
+       "s-4db06d37106e": -4,
+       "s-615b988a4f25": -3,
+       "s-6a6982330cce": 4,
+       "s-7ac48c95c8b3": -4,
+       "s-936972dfead1": 1,
+       "s-9c6e42d76a4a": 5,
+       "s-a4b2a6e5733c": -7,
+       "s-b605da8fdabe": 1,
+       "s-ba9ee60f1393": 1,
+       "s-cbd74b84ec45": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a55ba6fdd4eb3f81",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788566176.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "r-11fc7485e0f4",
+    "r-282af288890f",
+    "r-5211744ef5ac",
+    "r-67333332a462",
+    "r-708002f15b35",
+    "r-906e53a26db6",
+    "r-c8ccf8c88ea5",
+    "r-e01f534ebcc0",
+    "s-0cf03c0605e6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-7d60a789a72e"
+      ],
+      "only_ungated": [
+       "s-0cf03c0605e6"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0cf03c0605e6": -5,
+       "s-3c6e73e94951": 1,
+       "s-7d60a789a72e": 1,
+       "s-96497655bd79": 1,
+       "s-bac37138a440": 1,
+       "s-cfbc97e03c7b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:aa65f1bfda60bf58",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787874267.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-5cb16e67acc5",
+    "r-95628afa5412",
+    "r-a4d478bcb363",
+    "r-d3809a4821f6",
+    "r-e8676744236f",
+    "r-ffaf8f3617e7",
+    "s-11a84d232e72",
+    "s-be1daf56a3ed"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14
+    },
+    "ungated": {
+     "beliefs": 14
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-11a84d232e72": -6,
+       "s-1d3b874129b8": 1,
+       "s-2f03e0dc00b8": 1,
+       "s-664704a6f21e": 1,
+       "s-6ea924caad7d": 1,
+       "s-819bd16759cb": 1,
+       "s-be1daf56a3ed": -2,
+       "s-c68961ef5c0f": 1,
+       "s-ed7cd32eedae": 1,
+       "s-f3b77b019d06": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9c4f75cfd83b05e0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785624065.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "o-e4c698",
+    "r-9bd882",
+    "s-a6ee22",
+    "s-d55712",
+    "s-d61bc4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22,
+     "uncertainties": 11
+    },
+    "ungated": {
+     "beliefs": 22,
+     "uncertainties": 11
+    }
+   },
+   "positions_changed": 15,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-193f53": 1,
+       "o-194711": 1,
+       "o-6ccd26": 1,
+       "o-bb142d": 1,
+       "o-e4c698": -4
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-08d541": 2,
+       "s-0e8b7f": 3,
+       "s-330335": 3,
+       "s-93490c": 1,
+       "s-969dad": 3,
+       "s-a6ee22": -7,
+       "s-adea23": 3,
+       "s-d55712": -6,
+       "s-d61bc4": -5,
+       "s-f78537": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9c4f75cfd83b05e0",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1788129665.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-e4c698"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22,
+     "uncertainties": 9
+    },
+    "ungated": {
+     "beliefs": 22,
+     "uncertainties": 9
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-194711": 1,
+       "o-e4c698": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:bbc6fcdf059bfcc2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783643635.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-a50dbc",
+    "r-bf3b87",
+    "s-4d3d5a",
+    "s-e25412"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 11,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0cad78": 2,
+       "s-464a8b": 2,
+       "s-4d3d5a": -6,
+       "s-660d1c": 2,
+       "s-7d05da": 2,
+       "s-aa10d1": 1,
+       "s-cfba59": 1,
+       "s-e25412": -6,
+       "s-f57b52": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:98d37b23d30bdbaa",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786486969.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-0254237fe63d",
+    "r-76962418e0c7",
+    "r-8add52fa0b8c",
+    "r-d068f3add15d",
+    "r-e0065aa0020e",
+    "s-22ca2cf2ea76",
+    "s-da4df0f0f219"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 43,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 43,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-20e86f4b2932": 2,
+       "s-22ca2cf2ea76": -8,
+       "s-35e2d867f879": 1,
+       "s-671179e6e624": 2,
+       "s-84f4ae66dc81": 2,
+       "s-ae4baed02ad7": 2,
+       "s-bb5e6d7e3771": 2,
+       "s-c2310d1dc76d": 1,
+       "s-c96353813a91": 2,
+       "s-da4df0f0f219": -8,
+       "s-e77099ca114d": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:80344fd26a6480ad",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784491373.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-3abf6d",
+    "r-90a5da",
+    "r-d0f261",
+    "r-f0844e",
+    "s-967200"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 8,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 8,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-034aa1": 1,
+       "s-3cf3c8": 1,
+       "s-65636b": 1,
+       "s-967200": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e2caddf14b4d39c3",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788738774.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-06f2de8bb2a2",
+    "r-9951f51f0b4a",
+    "r-b0152344ca63",
+    "s-2ddd1c5dd6b4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17
+    },
+    "ungated": {
+     "beliefs": 17
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1e5b8e69a3cc": 1,
+       "s-2ddd1c5dd6b4": -3,
+       "s-709331af7b9f": 1,
+       "s-a3601f3217d2": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a9a67a00195b48b6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787973608.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-4944b1a41608",
+    "r-59d133b421d9",
+    "r-960f13fcbabd",
+    "r-b521c39f64f4",
+    "s-71ab07e4f94f",
+    "s-ba10bc5455ce",
+    "s-d21851489b7a",
+    "s-de6e6e64a9b9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 24,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 24,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0350664c37c0": 4,
+       "s-0505851d0abe": 4,
+       "s-30d93d834195": 4,
+       "s-3ac67653e89b": 2,
+       "s-3caa96dce1be": 4,
+       "s-3f52c0e71f0e": 4,
+       "s-6387e3a0bdd4": 1,
+       "s-71ab07e4f94f": -10,
+       "s-7988631cdf8f": 4,
+       "s-816437aceaf3": 4,
+       "s-b1ad31c71e80": 4,
+       "s-ba10bc5455ce": -11,
+       "s-be5b954f2907": 4,
+       "s-c814f11cf146": 4,
+       "s-ce268be55866": 1,
+       "s-d21851489b7a": -12,
+       "s-de6e6e64a9b9": -11
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:7c909591affada0c",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788072836.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 12,
+   "lid_biting_items": [
+    "r-301d432515ea",
+    "r-38326382407d",
+    "r-576e7ef3b1c1",
+    "r-a75c9a485593",
+    "r-c1c11a228909",
+    "r-cab5f655c571",
+    "r-d262d0d0afe7",
+    "r-fc6811606b79",
+    "s-3295458aba4e",
+    "s-3da6234d34f0",
+    "s-c092997c421a",
+    "s-d16ccb3fdda6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 23
+    },
+    "ungated": {
+     "beliefs": 23
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-780991314841",
+       "s-dfa833260b94"
+      ],
+      "only_ungated": [
+       "s-c092997c421a",
+       "s-d16ccb3fdda6"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0496933196ef": 4,
+       "s-3295458aba4e": -7,
+       "s-3da6234d34f0": -5,
+       "s-3ece4db0f5d8": 4,
+       "s-493833485fa9": 4,
+       "s-780991314841": 3,
+       "s-ac2a9fdb249e": 4,
+       "s-c092997c421a": -7,
+       "s-d16ccb3fdda6": -7,
+       "s-d98e849461e7": 4,
+       "s-dfa833260b94": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:aab67383df771ff0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788045064.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "s-531ef892c6e6",
+    "s-8e9563712806",
+    "s-c72d74c5b78e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11
+    },
+    "ungated": {
+     "beliefs": 11
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-b7834ea83855",
+       "s-d05211b0f977"
+      ],
+      "only_ungated": [
+       "s-531ef892c6e6",
+       "s-8e9563712806"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-25ddef32300f": 3,
+       "s-531ef892c6e6": -9,
+       "s-789f2eba42a9": 2,
+       "s-893f156a058b": 3,
+       "s-8e9563712806": -8,
+       "s-996af3e91785": 2,
+       "s-af94c19832d9": 2,
+       "s-b7834ea83855": 2,
+       "s-c72d74c5b78e": -3,
+       "s-d05211b0f977": 2,
+       "s-e3cef8cb1f5f": 1,
+       "s-e78f56815e0d": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3291ea07581596ef",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785646141.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-1b60e8",
+    "r-4444a7",
+    "r-65ca04",
+    "r-b03ffe",
+    "s-2be4b9",
+    "s-65fe6a"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "s-2be4b9"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 28,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 28,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 15,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 15,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-167f0a": 1,
+       "s-26f8d0": 1,
+       "s-2be4b9": -9,
+       "s-392b90": 1,
+       "s-574fdb": 1,
+       "s-65fe6a": -4,
+       "s-72185e": 1,
+       "s-77514b": 1,
+       "s-815fee": 1,
+       "s-9127f8": 1,
+       "s-a18f52": 1,
+       "s-ac7bf2": 1,
+       "s-b0c9e8": 1,
+       "s-e39f39": 1,
+       "s-f56a9e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:11feed210f512195",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788485329.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-c925d8a4423a",
+    "r-f556baf532ea",
+    "s-0f74a12bfd0b",
+    "s-7dfd3b7cf2f9",
+    "s-7f53e8bcbeba",
+    "s-a28aa1df858e",
+    "s-c06847922980",
+    "s-e717a4751ff2"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 39,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 39,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 27,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 27,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0f74a12bfd0b": -13,
+       "s-116febbe5090": 1,
+       "s-168222bd9a81": 6,
+       "s-1cf19b431a5a": 1,
+       "s-538633e383ef": 2,
+       "s-75633cacfb2d": 6,
+       "s-7dfd3b7cf2f9": -13,
+       "s-7eff17f03078": 6,
+       "s-7f53e8bcbeba": -18,
+       "s-8f1498e8327b": 2,
+       "s-992408c71add": 4,
+       "s-9cce4230b265": 6,
+       "s-9fbfc5845461": 6,
+       "s-a28aa1df858e": -9,
+       "s-a56b787a55d6": 5,
+       "s-ab306da3a5ec": 5,
+       "s-c06847922980": -13,
+       "s-c1413ea4c774": 6,
+       "s-cc61caac48fe": 2,
+       "s-d0ab6b50d0fa": 4,
+       "s-d6fd5cb63d00": 2,
+       "s-d71485edae2d": 1,
+       "s-d8fad009d8cc": 5,
+       "s-da5ba7591668": 5,
+       "s-e717a4751ff2": -16,
+       "s-f9308ac9dacc": 5,
+       "s-fb51a74437e8": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:83171034439b3711",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788724946.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "o-133a2ace9130",
+    "o-884d28597791",
+    "r-62075dfde769",
+    "r-ce71a13a7c1c",
+    "s-d59bfdb345e0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-133a2ace9130": -1,
+       "o-ca29e02eebdf": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-410e4b9bb418": 1,
+       "s-453df44b60fc": 1,
+       "s-602e1f3cf22a": 1,
+       "s-78b76ad5f725": 1,
+       "s-8a63b3b25c59": 1,
+       "s-aecaa92fd59c": 1,
+       "s-d59bfdb345e0": -7,
+       "s-fdd7cb10f879": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:83c7dbd471c0fc59",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788208703.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-2c6bfd640474",
+    "r-2cfd99886915",
+    "r-cbb8e6798a8f",
+    "r-dda72a321849",
+    "r-fdaa730b26e3",
+    "s-95a34473f0db"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20
+    },
+    "ungated": {
+     "beliefs": 20
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-9e25870ae5a7"
+      ],
+      "only_ungated": [
+       "s-95a34473f0db"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0a0b9409d089": 1,
+       "s-1d844919adbe": 1,
+       "s-30dbf21dc389": 1,
+       "s-3afe38c7b37b": 1,
+       "s-4cc18a4f504b": 1,
+       "s-8c79a4474cb7": 1,
+       "s-95a34473f0db": -9,
+       "s-9e25870ae5a7": 1,
+       "s-a2daf26de8e8": 1,
+       "s-c9709620a88b": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:17ddb8da81034483",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787719417.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-357a55bf969e",
+    "r-439994898d30",
+    "r-48c19eb2fcaa",
+    "r-4918ca25b1d6",
+    "r-d2155712ed90",
+    "r-dda6532bd12f",
+    "s-a9f68c54255a"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-357a55bf969e"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3fb14b462a94": 1,
+       "s-40cb112effed": 1,
+       "s-7202da8288ec": 1,
+       "s-a9f68c54255a": -5,
+       "s-b2a3649f4138": 1,
+       "s-bed5368993d8": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:43ae4fb406804a59",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788566526.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 13,
+   "lid_biting_items": [
+    "h:4cbf0acbdd73",
+    "o-5b8df357c64d",
+    "r-01e87a33ad7a",
+    "r-05d4d3cb90ce",
+    "r-498681ab50a8",
+    "r-622ee6d6c2ed",
+    "r-782c8a1e7971",
+    "r-78726d23d29e",
+    "r-98f6a04559e7",
+    "r-c68c7be529ff",
+    "r-cfa70b9c6559",
+    "s-3662aca3c5e6",
+    "s-f1d0e84ff346"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-46389c74b8fe": 1,
+       "o-5b8df357c64d": -2,
+       "o-9ac19e49ba62": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-6427f5243dfa": 1,
+       "s-7233d967d13e": 1,
+       "s-a2250fe46105": 1,
+       "s-f1d0e84ff346": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0a994844bb6d5e55",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788227095.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-0cf43d70571a",
+    "r-21ccad63cc49",
+    "s-45ec593266f0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 18,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 18,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0c42801d301e": 1,
+       "s-45ec593266f0": -3,
+       "s-a8d977c0c397": 1,
+       "s-fb9a5c077e10": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f9060dbaa33ffd39",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787731190.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-4f8ec49e308e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1d84784f5ca3": 1,
+       "s-4f8ec49e308e": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ab039b33b31f1bfc",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786566739.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "o-23f095b8d292",
+    "r-b9f59a1eff45",
+    "r-ff33b95a9dfa",
+    "s-03e71c64813e",
+    "s-31219f6ec851",
+    "s-c506ebc6287e"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-b9f59a1eff45"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 10
+    },
+    "ungated": {
+     "beliefs": 11
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 5,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 5,
+      "only_gated": [
+       "s-35f32a0ea42c",
+       "s-c6362fdd9404",
+       "s-d3ef514fdbdf"
+      ],
+      "only_ungated": [
+       "s-03e71c64813e",
+       "s-31219f6ec851"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-03e71c64813e": -7,
+       "s-31219f6ec851": -7,
+       "s-35f32a0ea42c": 3,
+       "s-37cbdc17aa68": 3,
+       "s-4e5907854c7b": 3,
+       "s-79c80a00b71b": 3,
+       "s-c506ebc6287e": -7,
+       "s-c6362fdd9404": 3,
+       "s-d3ef514fdbdf": 3,
+       "s-e6822c584547": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:18c86dddd74a3df9",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783707432.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-49d4f9",
+    "r-93be30",
+    "r-ca178e",
+    "r-fdbba6",
+    "s-0af651",
+    "s-b98849"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0af651": -2,
+       "s-0c4c27": 1,
+       "s-246e2b": 1,
+       "s-5f8192": 1,
+       "s-8d6cb3": 1,
+       "s-b98849": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d197af4c4fd2b58b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786169977.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-267c6fd10a4d",
+    "r-3dcce53710ee",
+    "r-40e01b83195d",
+    "r-593717d8006e",
+    "r-f526da0b5152",
+    "r-feb10d813c69",
+    "s-f96512e8679d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 26,
+     "uncertainties": 15
+    },
+    "ungated": {
+     "beliefs": 26,
+     "uncertainties": 15
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-012372b269d9": 1,
+       "s-1892704c626c": 1,
+       "s-1d77f9c2c243": 1,
+       "s-250d4b668182": 1,
+       "s-4868da890c04": 1,
+       "s-a4bd656d2eb4": 1,
+       "s-e2b1910111d3": 1,
+       "s-f4f04a035922": 1,
+       "s-f96512e8679d": -8
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a6283d161832b463",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980610.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "o-0c534ec233e5",
+    "s-2cc172cfb276",
+    "s-43dba42d9c9b",
+    "s-a58bb909c4eb",
+    "s-f8968b74104d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 20,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-0c534ec233e5": -1,
+       "o-ab45356f01bb": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-09d5ee757f1f": 3,
+       "s-2cc172cfb276": -1,
+       "s-3a111d158a31": 1,
+       "s-3bc4dcee0111": 1,
+       "s-3d1f5132ef42": 4,
+       "s-43dba42d9c9b": -5,
+       "s-a58bb909c4eb": -2,
+       "s-bdef55880e16": 1,
+       "s-f8968b74104d": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f6973d7a2296b73b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783885704.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 10,
+   "lid_biting_items": [
+    "h:98c728648315",
+    "o-b0e282",
+    "o-b5bf12",
+    "o-efa5bd",
+    "r-0b5986",
+    "r-50c6e1",
+    "r-6e5ba4",
+    "r-92c441",
+    "r-ace97a",
+    "r-d94980"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 2
+    },
+    "ungated": {
+     "beliefs": 2
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-079fca": 1,
+       "o-0c6bf1": 1,
+       "o-0eeaed": 2,
+       "o-4987c0": 3,
+       "o-9ad8c1": 2,
+       "o-b0e282": -5,
+       "o-b5bf12": -3,
+       "o-efa5bd": -6,
+       "o-f90f0c": 2,
+       "o-fc5797": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f6973d7a2296b73b",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1786391304.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-b0e282",
+    "o-b5bf12"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 2
+    },
+    "ungated": {
+     "beliefs": 2
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-b0e282": -1,
+       "o-f90f0c": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4f70ff09d9264aea",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785380786.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 14,
+   "lid_biting_items": [
+    "o-180dcf",
+    "r-18bcad",
+    "r-414bfa",
+    "r-507507",
+    "r-6b7afa",
+    "r-7b54b0",
+    "r-9f4bc7",
+    "r-b6b229",
+    "r-c762a6",
+    "r-d1d479",
+    "r-f9a267",
+    "s-05e0ee",
+    "s-17d2fe",
+    "s-9be302"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-180dcf": -3,
+       "o-7dc360": 1,
+       "o-a2200e": 1,
+       "o-ce8dda": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-05e0ee": -4,
+       "s-145b49": 2,
+       "s-17d2fe": -1,
+       "s-4422f2": 2,
+       "s-8e144a": 2,
+       "s-9be302": -4,
+       "s-dc9601": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4f70ff09d9264aea",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1787886386.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-180dcf"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "open_loops": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-180dcf": -1,
+       "o-a2200e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ef804bf0511d198b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789062840.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-daed0f658c5d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11
+    },
+    "ungated": {
+     "beliefs": 11
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-5d34bcc9892e": 1,
+       "s-832f0be559ce": 1,
+       "s-ad965b1f7c6a": 1,
+       "s-cae2c9fb82d9": 1,
+       "s-cbc33de4ec08": 1,
+       "s-daed0f658c5d": -6,
+       "s-f4d14df85336": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:adec2788bd28ec70",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788981127.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-1fd8f63ffc9a",
+    "r-50d6258c2050",
+    "r-64cc8d3673e9",
+    "s-5b8463ca4c3b",
+    "s-612b1eecc162",
+    "s-e2fded700c7a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 16
+    },
+    "ungated": {
+     "beliefs": 16
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2dc093e62750": 3,
+       "s-4eff64efc019": 2,
+       "s-5b8463ca4c3b": -2,
+       "s-612b1eecc162": -3,
+       "s-8140031f08ec": 3,
+       "s-e2fded700c7a": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4758931676b285b1",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784267202.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-6e3ba8",
+    "s-c6a909"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14,
+     "uncertainties": 15,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 14,
+     "uncertainties": 15,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-363d02": 1,
+       "s-55b441": 1,
+       "s-6b2ef3": 1,
+       "s-6e3ba8": -3,
+       "s-a0077c": 2,
+       "s-c2c30d": 1,
+       "s-c6a909": -5,
+       "s-e0e79d": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e227ba504a1fd9c2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786136444.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-0496d1f19a31",
+    "r-32d7432bf727",
+    "r-3df311005ec6",
+    "r-446ab004f7e9",
+    "r-d5ee48980e16",
+    "r-e1669d5e6595",
+    "s-c5057475566f"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 26,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 26,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-24e32c57826f": 1,
+       "s-65723f387976": 1,
+       "s-706e60491bd3": 1,
+       "s-70e27d904901": 1,
+       "s-84a5159ef514": 1,
+       "s-8cb3cd148b2f": 1,
+       "s-c5057475566f": -6
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:a1d241c9a572e83b",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788137126.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 7,
+   "lid_biting_items": [
+    "r-0c2dc34297ee",
+    "r-5a46198e7b74",
+    "r-cbbe5d6f8ee6",
+    "s-5328b860bc11",
+    "s-6747e9a8ebce",
+    "s-7a97934db526",
+    "s-d235aabc2a25"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22
+    },
+    "ungated": {
+     "beliefs": 22
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-e2265b25dce0"
+      ],
+      "only_ungated": [
+       "s-d235aabc2a25"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0ea74cf0c460": 1,
+       "s-1e65bdc15dc6": 2,
+       "s-5328b860bc11": -4,
+       "s-57cda32501ae": 2,
+       "s-6747e9a8ebce": -4,
+       "s-6ef68ba99d2d": 4,
+       "s-71c3e4ab1769": 2,
+       "s-7a97934db526": -4,
+       "s-ab47672280fe": 2,
+       "s-cbf1f91a592d": 2,
+       "s-d235aabc2a25": -5,
+       "s-e2265b25dce0": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3dab2e6554fefffa",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786262504.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-2d020b949dbc",
+    "r-7e24bd6465dc",
+    "r-a5523f86f1a4",
+    "s-6ae963013055",
+    "s-afec8af1c86b",
+    "s-f252fc69809a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14,
+     "uncertainties": 13
+    },
+    "ungated": {
+     "beliefs": 14,
+     "uncertainties": 13
+    }
+   },
+   "positions_changed": 11,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 11,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0ac6bfc8327d": 2,
+       "s-29dfb554df20": 2,
+       "s-4de58148c54e": 2,
+       "s-6ae963013055": -5,
+       "s-89c142d1d7d4": 1,
+       "s-a281dcd52243": 1,
+       "s-a2b89f9e6c7e": 2,
+       "s-afec8af1c86b": -5,
+       "s-b33aaeb8f388": 2,
+       "s-c07796c624da": 1,
+       "s-f252fc69809a": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:0c56f32870126393",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788924052.0,
+   "n_flipped_items": 17,
+   "n_lid_biting_flips": 14,
+   "lid_biting_items": [
+    "h:4ad62bdf2f80",
+    "o-e41361fec573",
+    "r-32a35fb91846",
+    "r-3a3bf95de863",
+    "r-53fcec27720d",
+    "r-5be93d88e5d5",
+    "r-5fcf62787c23",
+    "r-8b813bf17469",
+    "r-995da7e9e75c",
+    "r-9aff256eb553",
+    "r-ba1974ad30c0",
+    "r-bb44d9241c4c",
+    "r-e5b05d0c560b",
+    "r-f11084d4be04"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 46,
+     "uncertainties": 7
+    },
+    "ungated": {
+     "beliefs": 46,
+     "uncertainties": 7
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-10c641ba515b": 1,
+       "o-626bed186bfc": 1,
+       "o-c911ee26435c": 1,
+       "o-e41361fec573": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:da90a753b9058c48",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787811909.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-1b13d3b836cf",
+    "r-603e6405f0a4",
+    "s-dd82e069f3d7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 10
+    },
+    "ungated": {
+     "beliefs": 10
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-b233c35aa060": 1,
+       "s-ce3701c060c0": 1,
+       "s-dd82e069f3d7": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9b3441f3c1ebf89d",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980569.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-5a94a45bcd16",
+    "r-6051b21017c8",
+    "r-76d23797791e",
+    "s-0c405f09782f",
+    "s-677b85a59ab6",
+    "s-7322df280183",
+    "s-85bb5373e5f8",
+    "u-4c3f43b9e992"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 21
+    },
+    "ungated": {
+     "beliefs": 21
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-030f533cdcfd"
+      ],
+      "only_ungated": [
+       "s-0c405f09782f"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-030f533cdcfd": 1,
+       "s-04f6eec35c08": 3,
+       "s-05e99d8dd04d": 1,
+       "s-0c405f09782f": -6,
+       "s-15cc5416834e": 2,
+       "s-57f55bb7cf90": 2,
+       "s-5de8011a6c6e": 2,
+       "s-677b85a59ab6": -2,
+       "s-7322df280183": -4,
+       "s-85bb5373e5f8": -5,
+       "s-ddc5a1cc83d5": 3,
+       "s-e150555b2e1e": 3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ff354b897368d7bf",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785902827.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "h:b21b3b7619e9",
+    "o-6fa594f32a8b",
+    "r-6bcba44cdda5",
+    "r-78ced05ab057",
+    "r-b010262e30e9",
+    "s-3a10ebc70551"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 22,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-6fa594f32a8b": -1,
+       "o-dcd9a4ad02d9": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-23c1b07d18db": 1,
+       "s-245868b85390": 1,
+       "s-39b3a1b3e499": 1,
+       "s-3a10ebc70551": -7,
+       "s-b9fe5a3f2082": 1,
+       "s-bbca9611666c": 1,
+       "s-cb2b1c7f44bb": 1,
+       "s-f23dfa018ac8": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:8030d66d1ec60adb",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786774720.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-684deac31fed",
+    "r-adefff38636c",
+    "s-595568e69baa",
+    "s-87e9485d2ab7"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3c0eaf620489": 2,
+       "s-595568e69baa": -6,
+       "s-62b9807c3d57": 2,
+       "s-726978e3ea4d": 1,
+       "s-82e4d653597a": 2,
+       "s-87e9485d2ab7": -5,
+       "s-abb895fbfbb8": 2,
+       "s-ed74f28e357f": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f3dd947ba94b4d22",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788249133.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-47cbbb4fb209",
+    "s-27ac16e736ed",
+    "s-8188c7a828c4",
+    "s-9d94ac26b546",
+    "u-c6131e775fe4"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 7,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0e9ba98943ff": 2,
+       "s-1a5f8c6eee8b": 3,
+       "s-27ac16e736ed": -1,
+       "s-3653d2277143": 2,
+       "s-8188c7a828c4": -4,
+       "s-9d94ac26b546": -4,
+       "s-ad6cdb000f74": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:529a6e7eea86d586",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788892017.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "r-1ed3d044fa90",
+    "r-5444e34f437c",
+    "r-b840c213a11a",
+    "s-03f452d0f87b",
+    "s-072187aa7f9d",
+    "s-523e27c1231a",
+    "s-bb4b9efbf020",
+    "s-bb7dfa28c1e8",
+    "s-f0611f17ae6e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 28,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 28,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-03f452d0f87b": -4,
+       "s-049041be43ab": 5,
+       "s-072187aa7f9d": -10,
+       "s-192d1c93f1db": 3,
+       "s-278e2a1aec14": 6,
+       "s-523e27c1231a": -10,
+       "s-71e90fe5b5ee": 1,
+       "s-78b7bc561d53": 3,
+       "s-8cc8cd3128a2": 6,
+       "s-a4d142a848cc": 3,
+       "s-ae90bdf41a32": 3,
+       "s-b69cb2987e23": 4,
+       "s-bb4b9efbf020": -4,
+       "s-bb7dfa28c1e8": -10,
+       "s-c6990c83f8c2": 3,
+       "s-eb0b6c2f47db": 6,
+       "s-f0611f17ae6e": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f502090a2ceed0ba",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786042990.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-a325a0e291a5",
+    "s-39bb12b97973",
+    "s-78da2da41df9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 18,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 18,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-04ef6ab0c304": 2,
+       "s-39bb12b97973": -5,
+       "s-3e1594d98755": 2,
+       "s-4959156519f9": 2,
+       "s-5213c7a629fa": 1,
+       "s-6433c156ae35": 2,
+       "s-78da2da41df9": -5,
+       "s-f7f68860a0ae": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:84a197857d20e054",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783669488.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-fc77db",
+    "s-c4b92d",
+    "s-e63dfb"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-fc77db"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 2
+    },
+    "ungated": {
+     "beliefs": 2
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-3c8e30"
+      ],
+      "only_ungated": [
+       "s-c4b92d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3c8e30": 2,
+       "s-8e76cd": 2,
+       "s-c4b92d": -2,
+       "s-e63dfb": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b113c57d6827b061",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787802731.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-68cac233fb7d",
+    "s-8c81bb82ca15"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3f451d1a34cb": 2,
+       "s-68cac233fb7d": -1,
+       "s-8c81bb82ca15": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:eb64f67d1163d060",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789013429.0,
+   "n_flipped_items": 11,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "s-2f9d3fb1a1f0",
+    "s-58dbf97d280b",
+    "s-78c22beb1d6d",
+    "s-9f733308a38d",
+    "s-af7be76512ae",
+    "s-d69308241044"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 26,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 26,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 14,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 14,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-09d5269fed2a": 4,
+       "s-0efa47fca1f0": 2,
+       "s-2f9d3fb1a1f0": -5,
+       "s-488e5a04a0ba": 5,
+       "s-58dbf97d280b": -5,
+       "s-6e6dba92b227": 3,
+       "s-78c22beb1d6d": -4,
+       "s-8048d39ec9bb": 5,
+       "s-94a4e48b5eba": 1,
+       "s-9f733308a38d": -3,
+       "s-af7be76512ae": -5,
+       "s-bc9f593bef9e": 5,
+       "s-bed520699891": 2,
+       "s-d69308241044": -5
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1b0ba6e5b8ef55ec",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789176406.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-05d5cc118883",
+    "r-80b226337f04",
+    "s-3ad2e68c81e0",
+    "s-4fb7063ee795",
+    "s-85ad2f367e5b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3ad2e68c81e0": -1,
+       "s-3ee6cbe0cf39": 1,
+       "s-4fb7063ee795": -3,
+       "s-85ad2f367e5b": -1,
+       "s-8967aa99c960": 3,
+       "s-c990525d81c4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3492dfe84073ed43",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788247161.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-805c50edbf58",
+    "s-1c0c846d50d9",
+    "s-7538b336f3dc",
+    "s-b9c0357f3e96"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 25,
+     "uncertainties": 2
+    },
+    "ungated": {
+     "beliefs": 25,
+     "uncertainties": 2
+    }
+   },
+   "positions_changed": 14,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 14,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1c0c846d50d9": -3,
+       "s-1f7a55c1ce8e": 1,
+       "s-5275e14733ac": 1,
+       "s-7538b336f3dc": -3,
+       "s-8d685778a6f2": 1,
+       "s-92f20934fb36": 1,
+       "s-99e55152ecd6": 2,
+       "s-ae52135cd60d": 1,
+       "s-ae97eeb988f7": 3,
+       "s-b951f9a003c7": 1,
+       "s-b9c0357f3e96": -9,
+       "s-bf12fbf55e24": 1,
+       "s-cc1d0741882b": 2,
+       "s-eadfe889ac68": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:5972eadee2640ec2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980945.0,
+   "n_flipped_items": 19,
+   "n_lid_biting_flips": 17,
+   "lid_biting_items": [
+    "h:99e42dfe2938",
+    "r-0f1d56e656b7",
+    "r-2009748f4cdb",
+    "r-6ad17412b0be",
+    "r-9731ddc4f174",
+    "r-9867c097bf4d",
+    "r-a3eaa03cf828",
+    "r-c044d7edb5f0",
+    "r-e69bc19bd0e6",
+    "s-04dece143d52",
+    "s-28643d000f9a",
+    "s-35697cf0a7b2",
+    "s-55cedf866b6f",
+    "s-730748221d37",
+    "s-8819f107781a",
+    "s-b6c81807b5e7",
+    "s-bafaa6b06351"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 40,
+     "uncertainties": 21,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 40,
+     "uncertainties": 21,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 20,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 20,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-020468f1dfeb": 7,
+       "s-0225b0e6e55b": 4,
+       "s-04dece143d52": -5,
+       "s-216e1695c671": 5,
+       "s-28643d000f9a": -8,
+       "s-335347ed6e2b": 1,
+       "s-35697cf0a7b2": -3,
+       "s-375fc7c30a01": 3,
+       "s-55cedf866b6f": -5,
+       "s-652ea2ccda71": 4,
+       "s-730748221d37": -9,
+       "s-7969f3ade184": 3,
+       "s-861bb07a6014": 4,
+       "s-8819f107781a": -9,
+       "s-ad36fc031bb5": 7,
+       "s-b6c81807b5e7": -5,
+       "s-bac5f45c7579": 7,
+       "s-bafaa6b06351": -9,
+       "s-d4c29ad5eea3": 4,
+       "s-eda44702896b": 4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f94f7ccefde30fa6",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784513815.0,
+   "n_flipped_items": 5,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-23dd02",
+    "r-ae0645",
+    "s-908958",
+    "s-d3a45d",
+    "u-26f92e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2738c4": 1,
+       "s-d3a45d": -1
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-26f92e": -1,
+       "u-9c3f68": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:76b2245ab49e54a3",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788052554.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-12db08ce4e8a",
+    "s-58e65c1c4cb5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 11
+    },
+    "ungated": {
+     "beliefs": 11
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-58e65c1c4cb5": -4,
+       "s-6c3cfb4336ae": 1,
+       "s-b0e5fe1700d0": 1,
+       "s-bd98eeb60865": 1,
+       "s-c36d3498f9a0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:54d7fe1636b1a5cd",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786504465.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-0aa2bcc34d85",
+    "r-71302d91e245",
+    "r-8fd56d44e05a",
+    "r-b1cc2df0ce2f",
+    "s-8ca9ac975e1b",
+    "s-9b3aab1491f1",
+    "s-a39eccfea9c3",
+    "s-faaf96b10cb9"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 6
+    },
+    "ungated": {
+     "beliefs": 6
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 4,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 4,
+      "only_gated": [
+       "s-56546a4e0ab3",
+       "s-921c1bc4c032"
+      ],
+      "only_ungated": [
+       "s-8ca9ac975e1b",
+       "s-9b3aab1491f1"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-22a4ccca0c9c": 4,
+       "s-56546a4e0ab3": 4,
+       "s-60dd9edb58ff": 4,
+       "s-8ca9ac975e1b": -6,
+       "s-921c1bc4c032": 3,
+       "s-9b3aab1491f1": -4,
+       "s-a39eccfea9c3": -4,
+       "s-a5374aec50f1": 1,
+       "s-b13e3a6cefd8": 1,
+       "s-faaf96b10cb9": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d4ea6957ae820ad0",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785531102.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 14,
+   "lid_biting_items": [
+    "o-3197fa",
+    "o-c7c3d5",
+    "o-ffc7af",
+    "r-2580a5",
+    "r-2c5793",
+    "r-4dca60",
+    "r-5b79a5",
+    "r-d6d8c2",
+    "r-eb1e1a",
+    "r-f0130f",
+    "s-26326d",
+    "s-54da91",
+    "s-817383",
+    "u-1876cc"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17
+    },
+    "ungated": {
+     "beliefs": 20
+    }
+   },
+   "positions_changed": 26,
+   "cap_crossings": 5,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-3197fa": -4,
+       "o-60c766": 2,
+       "o-65c4e3": 2,
+       "o-6ccd26": 2,
+       "o-bb142d": 2,
+       "o-ffc7af": -4
+      }
+     }
+    },
+    "open_loops": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-4b01ff": 1,
+       "o-548468": 1,
+       "o-5762e8": 1,
+       "o-8c0397": 1,
+       "o-b74444": 1,
+       "o-c7c3d5": -6,
+       "o-e3c230": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 5,
+      "only_gated": [
+       "s-8a523d",
+       "s-c9115d",
+       "s-e0a40e",
+       "s-f7eeef"
+      ],
+      "only_ungated": [
+       "s-26326d"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-26326d": -6,
+       "s-4aa62a": 3,
+       "s-54da91": -5,
+       "s-817383": -6,
+       "s-8a523d": 3,
+       "s-957823": 3,
+       "s-c9115d": 3,
+       "s-e0a40e": 3,
+       "s-f7eeef": 2
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-1876cc": -3,
+       "u-d1b3ec": 1,
+       "u-df22f3": 1,
+       "u-f83ec1": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d4ea6957ae820ad0",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1788036702.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-3197fa",
+    "o-c7c3d5",
+    "o-ffc7af"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 20
+    },
+    "ungated": {
+     "beliefs": 20
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-3197fa": -3,
+       "o-60c766": 2,
+       "o-65c4e3": 2,
+       "o-bb142d": 2,
+       "o-ffc7af": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2a7cc3ca452c9079",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788889182.0,
+   "n_flipped_items": 7,
+   "n_lid_biting_flips": 6,
+   "lid_biting_items": [
+    "r-0afc9629dbd7",
+    "r-7f8d857d0e8b",
+    "r-b0ce28c410c7",
+    "r-f6fdf7371ef2",
+    "r-fa1cc5b2787b",
+    "s-bce03542f86e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-101815e3ade6": 1,
+       "s-bce03542f86e": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:3ac53587cd0d34b5",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788980299.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-4ad52585a6f0",
+    "s-cc5dd42bb1b0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 22,
+     "uncertainties": 8
+    },
+    "ungated": {
+     "beliefs": 22,
+     "uncertainties": 8
+    }
+   },
+   "positions_changed": 9,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 9,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1350014be3b7": 2,
+       "s-4ad52585a6f0": -6,
+       "s-8497e6618288": 2,
+       "s-a569e29db964": 2,
+       "s-cc5dd42bb1b0": -7,
+       "s-e051fda167ce": 1,
+       "s-e562309585e7": 2,
+       "s-f1d57189e8c3": 2,
+       "s-f3738d0076eb": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f46b3758c1a23de8",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786082101.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "h:71680316bdb6",
+    "r-b474e2151408",
+    "s-3a94c506987c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-3a94c506987c": -1,
+       "s-a91c3b98c508": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:eefb2d2dbff89cd4",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786913944.0,
+   "n_flipped_items": 6,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "h:b7970c54cbdc",
+    "r-01a65cdd04b0",
+    "s-0b3c73f00ffa",
+    "s-2f10cede81ed"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0b3c73f00ffa": -3,
+       "s-2f10cede81ed": -6,
+       "s-48f0c30e7ecf": 2,
+       "s-5a6872c689fe": 1,
+       "s-5d5c7dcb308a": 1,
+       "s-5f34f3e1fc67": 2,
+       "s-cec4e9181fcf": 1,
+       "s-e0f8a632b795": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:744a1ed496d01c02",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783793677.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-782e80",
+    "r-84d346",
+    "u-58ea51"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 4
+    },
+    "ungated": {
+     "beliefs": 4
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "uncertainties": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-253f49": 1,
+       "u-4a151b": 1,
+       "u-58ea51": -5,
+       "u-5ca1f0": 1,
+       "u-8fad4a": 1,
+       "u-fd0e74": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:6fa913e002507306",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785707067.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "h:420d8b0d3232",
+    "r-0a3c1301b674",
+    "r-3f298fc9fd56",
+    "r-8ec210bb1db6",
+    "r-a6390f161975",
+    "r-b3ec7737467d",
+    "r-bd05fb69f4c7",
+    "r-e9ed56d65e45",
+    "s-e6b5acd7f1b6"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12,
+     "uncertainties": 6
+    },
+    "ungated": {
+     "beliefs": 12,
+     "uncertainties": 6
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-46e77aac1a8c": 1,
+       "s-6236e67e72f9": 1,
+       "s-d381d9ff15d1": 1,
+       "s-e6b5acd7f1b6": -3
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2a52a615fb4b2e31",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1783726945.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 8,
+   "lid_biting_items": [
+    "r-30751d",
+    "r-8cc053",
+    "r-b2f453",
+    "s-57fca2",
+    "s-80dcc0",
+    "s-c79a2e",
+    "u-6d75e8",
+    "u-7d7a5e"
+   ],
+   "n_truncation_exempting_flips": 1,
+   "truncation_exempting_items": [
+    "r-30751d"
+   ],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 7,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-57fca2": -3,
+       "s-80dcc0": -2,
+       "s-817892": 2,
+       "s-8cbc53": 2,
+       "s-c79a2e": -3,
+       "s-cc165d": 1,
+       "s-feca74": 3
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-167e68": 2,
+       "u-6d75e8": -1,
+       "u-7d7a5e": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2410ac954f908427",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786153021.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-86bddfcc3b3b",
+    "u-0ece300f80f5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 9,
+     "uncertainties": 10
+    },
+    "ungated": {
+     "beliefs": 9,
+     "uncertainties": 10
+    }
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1638463ff19e": 1,
+       "s-86bddfcc3b3b": -3,
+       "s-9f1023113877": 1,
+       "s-cc29b609b2a4": 1
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-0ece300f80f5": -1,
+       "u-76051102e542": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f638ace02911e2ab",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788674981.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-347acc9ba2c1",
+    "r-36ba636d8141",
+    "r-8b534d7e9fb7",
+    "s-3c0ca4653cdb",
+    "s-97ea9edbf5fd"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 27,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 27,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-01865d51b0bd": 2,
+       "s-1b361ad651e4": 2,
+       "s-28b19a7f512e": 1,
+       "s-3c0ca4653cdb": -9,
+       "s-55f9752cbd54": 2,
+       "s-5a4196ab726d": 1,
+       "s-5d00da966a72": 2,
+       "s-6241930d9d76": 1,
+       "s-7b2f567591ee": 1,
+       "s-8b3ffce8d021": 2,
+       "s-97ea9edbf5fd": -14,
+       "s-b3092086f728": 1,
+       "s-d01dabdbc8f4": 2,
+       "s-d293f9d62643": 1,
+       "s-e2e46ac0f8a3": 1,
+       "s-ef933a11e4e9": 2,
+       "s-faceac53fc70": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cb7374f4a0719896",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785954203.0,
+   "n_flipped_items": 15,
+   "n_lid_biting_flips": 14,
+   "lid_biting_items": [
+    "r-00f22dec9d1f",
+    "r-21b993a16d7d",
+    "r-22be0d8b7827",
+    "r-60f86def3484",
+    "r-a57b8f7f4e81",
+    "r-b94cdedb9510",
+    "r-d60cc56a499c",
+    "r-f87e128d3cf0",
+    "r-f8fb625c7854",
+    "s-284ce5de5944",
+    "s-37133b7f1935",
+    "s-6cfd5c1e5615",
+    "s-e9efc50fb461",
+    "s-fab7035d0efa"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 13
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 13
+    }
+   },
+   "positions_changed": 17,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 17,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0d216333f524": 2,
+       "s-11d224e0fe2b": 5,
+       "s-2116044bf38d": 1,
+       "s-284ce5de5944": -4,
+       "s-37133b7f1935": -7,
+       "s-47b102970a80": 4,
+       "s-5dc0f024d0f2": 2,
+       "s-6cfd5c1e5615": -10,
+       "s-7208295a3cb1": 3,
+       "s-8631d47a8e06": 4,
+       "s-8f8c889d93e2": 4,
+       "s-cb064b447c48": 2,
+       "s-d1212adf8f1e": 1,
+       "s-d24b3cdd2b9b": 5,
+       "s-d7af6c3128d5": 1,
+       "s-e9efc50fb461": -7,
+       "s-fab7035d0efa": -6
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:2cb2f9d2540ba636",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1784962548.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 9,
+   "lid_biting_items": [
+    "r-00036980ecd3",
+    "r-08f3a9683ad7",
+    "r-198247b1e2d1",
+    "r-58d79aa5b5ea",
+    "r-868d3eff115e",
+    "r-adda21c8dffd",
+    "r-fdf5c0d1a81c",
+    "s-24b4c614ebb7",
+    "s-87268b3bf912"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 23
+    },
+    "ungated": {
+     "beliefs": 23
+    }
+   },
+   "positions_changed": 18,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 18,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-c0b0cd074e91"
+      ],
+      "only_ungated": [
+       "s-87268b3bf912"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-0a3dc2b4bd49": 1,
+       "s-24b4c614ebb7": -4,
+       "s-25d5562ca9d6": 1,
+       "s-462780af0a06": 1,
+       "s-5c71b1e557f3": 1,
+       "s-62a9206a2a05": 1,
+       "s-6e0986084e5e": 1,
+       "s-6fcbf98a4092": 1,
+       "s-70705d77e389": 1,
+       "s-8127dfcc5940": 1,
+       "s-87268b3bf912": -12,
+       "s-8f7197e9e7dd": 1,
+       "s-961044e4780e": 1,
+       "s-970b0e7b01b5": 1,
+       "s-c0b0cd074e91": 1,
+       "s-f3d7c857ec31": 1,
+       "s-f69f4489004d": 1,
+       "s-f899e1f38491": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ebcab96dfb48446a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787971001.0,
+   "n_flipped_items": 14,
+   "n_lid_biting_flips": 12,
+   "lid_biting_items": [
+    "h:80fa5bae16f1",
+    "o-7cdc1b44faed",
+    "o-f0fa64daa1d0",
+    "r-1c8e507c8389",
+    "r-5f6b36ed6472",
+    "r-68ff24b84375",
+    "r-86d1014bebab",
+    "r-9bfb0988eea2",
+    "s-2a676bf74a48",
+    "s-c0823fa7911c",
+    "s-e26ea9ccd9a4",
+    "s-e81314aaa230"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 23
+    },
+    "ungated": {
+     "beliefs": 23
+    }
+   },
+   "positions_changed": 12,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 12,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1d441ba9a653": 4,
+       "s-2a676bf74a48": -8,
+       "s-30dfcd70ac05": 4,
+       "s-699c5c0e711f": 1,
+       "s-800844412855": 4,
+       "s-b94890f108f2": 4,
+       "s-c0823fa7911c": -7,
+       "s-c65d1c3abfe9": 4,
+       "s-e26ea9ccd9a4": -7,
+       "s-e5d40ad3a74c": 4,
+       "s-e81314aaa230": -7,
+       "s-ed3a7f138930": 4
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:4b1d1f44fd88f621",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1788647869.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-011bcba81af5"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-011bcba81af5": -1,
+       "o-55fba15a1ce4": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b8308695435769ec",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341804.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-cd0c8950dc84",
+    "s-ed1cc815927c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-4e26d42f9eb7": 1,
+       "s-ed1cc815927c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:de120412e3ea33d2",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341615.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-584f87a6e6ff",
+    "r-76437c462918",
+    "s-83e89144cb27"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-535c522dd09b": 1,
+       "s-699ae47ec3ee": 1,
+       "s-83e89144cb27": -4,
+       "s-f35978b781b0": 1,
+       "s-f6de5ed82b34": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:579387c6e3d06562",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789339075.0,
+   "n_flipped_items": 10,
+   "n_lid_biting_flips": 5,
+   "lid_biting_items": [
+    "r-38a0bb3be0f1",
+    "r-9a7d98cae503",
+    "s-092216a692db",
+    "s-4630b8adac76",
+    "s-79b0a318fd82"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19
+    },
+    "ungated": {
+     "beliefs": 19
+    }
+   },
+   "positions_changed": 8,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 8,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-092216a692db": -3,
+       "s-1709fc2250c8": 1,
+       "s-4630b8adac76": -2,
+       "s-56fee8dcaf96": 3,
+       "s-79b0a318fd82": -4,
+       "s-c40daa50e69c": 3,
+       "s-cbfd41611a09": 1,
+       "s-f35978b781b0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c2dbd14551a0808f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1785991138.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-13150c437ced",
+    "s-235a1ab1239e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 6,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 6,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-16b50ec80dd9": 1,
+       "s-235a1ab1239e": -3,
+       "s-3f35d6899ea3": 1,
+       "s-ebfa82f0ac8e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:f34fb515ee9a94d4",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786001989.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-77402a5543a1"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 5
+    },
+    "ungated": {
+     "beliefs": 5
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-2b0bb850e756": 1,
+       "s-77402a5543a1": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:cf383f4a105cf42a",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786074977.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-eeec0855ad2a",
+    "r-1bba44fdb031",
+    "s-0f57fc500139"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 1
+    },
+    "ungated": {
+     "beliefs": 1
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-de465008ef25": 1,
+       "o-eeec0855ad2a": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:ea1a11bdcb94c1b7",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1786250837.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-9c33b310ea88",
+    "r-ff3d5f2de1cd",
+    "s-bafea4bc8b6a",
+    "s-be240783231b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 3
+    },
+    "ungated": {
+     "beliefs": 3
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-bafea4bc8b6a": -1,
+       "s-be240783231b": -1,
+       "s-f3af909f9c3e": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:9061d3f82598b0cc",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1787987708.0,
+   "n_flipped_items": 3,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-8253a0bb1f8f",
+    "s-f537d54ba671"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 6,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 6,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-13420dc0a7f9": 1,
+       "s-693429a3250b": 1,
+       "s-8b48aba65dce": 1,
+       "s-8e3bac6369a5": 1,
+       "s-f537d54ba671": -5,
+       "s-f7f743024dae": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c04a48fc116b540d",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789019325.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-ddf57d4ff7ae"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-22cb833c3a91": 1,
+       "s-ddf57d4ff7ae": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:92dfad780f5bfd74",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789097092.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-c0901266a4ae"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 12
+    },
+    "ungated": {
+     "beliefs": 12
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-c0901266a4ae": -1,
+       "s-f4e347ee8890": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:5b538a1186ab4ec1",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789110340.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-54157723a522",
+    "s-1d824c3938c0",
+    "s-aca923ccd98c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 10,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-08d0b049753a": 1,
+       "s-1d824c3938c0": -8,
+       "s-44b93795d745": 2,
+       "s-9eef970b9b50": 2,
+       "s-a6078d0d41e7": 1,
+       "s-aca923ccd98c": -4,
+       "s-adb23efa7c8a": 1,
+       "s-c28f79b475aa": 1,
+       "s-ea867909bdbe": 2,
+       "s-eeb2ab38e3ed": 2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:49b5695b39214006",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789171338.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-b3c171f37727"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-500ccb1638d2": 1,
+       "s-b3c171f37727": -3,
+       "s-ce6f4cc3a264": 1,
+       "s-e64a4e845250": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:1c4bb8e889630916",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789114379.0,
+   "n_flipped_items": 1,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "s-92e8533d3b1b"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 7
+    },
+    "ungated": {
+     "beliefs": 7
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-165a15625ee4": 1,
+       "s-58c775a74778": 1,
+       "s-617413be7236": 1,
+       "s-92e8533d3b1b": -4,
+       "s-df007c78e928": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:e6a7d995f980b23f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789170132.0,
+   "n_flipped_items": 4,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "r-306e7486828f",
+    "r-76515fa230c1",
+    "r-83fb6cc39b4a",
+    "s-d719e79d2008"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 3,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-1b5ef4766b05": 1,
+       "s-c8b925718e9f": 1,
+       "s-d719e79d2008": -2
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:abd82274c31d5a25",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341615.0,
+   "n_flipped_items": 9,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "o-584f87a6e6ff",
+    "r-76437c462918",
+    "s-83e89144cb27"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 19,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 5,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-535c522dd09b": 1,
+       "s-699ae47ec3ee": 1,
+       "s-83e89144cb27": -4,
+       "s-f35978b781b0": 1,
+       "s-f6de5ed82b34": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:03ed409396503f45",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789261188.0,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 4,
+   "lid_biting_items": [
+    "o-515dbfd4d77e",
+    "r-8340d197fd58",
+    "s-7263c9f4b781",
+    "u-327e841c186d"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 15
+    },
+    "ungated": {
+     "beliefs": 15
+    }
+   },
+   "positions_changed": 10,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 5,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-515dbfd4d77e": -4,
+       "o-7b0dbaa567b3": 1,
+       "o-bdb0fd592ff3": 1,
+       "o-bf54b43c19c1": 1,
+       "o-f9d3e0bed4d4": 1
+      }
+     }
+    },
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-7263c9f4b781": -1,
+       "s-f888d3450938": 1
+      }
+     }
+    },
+    "uncertainties": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "u-29ee66c455e2": 1,
+       "u-327e841c186d": -2,
+       "u-a9d0c95c96d0": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:03ed409396503f45",
+   "source": "local",
+   "horizon_days": 30,
+   "now": 1791766788.0,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 1,
+   "lid_biting_items": [
+    "o-515dbfd4d77e"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 15
+    },
+    "ungated": {
+     "beliefs": 15
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-515dbfd4d77e": -1,
+       "o-7b0dbaa567b3": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:c69781e9533ac479",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789176047.0,
+   "n_flipped_items": 2,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "s-54ae239c88dc",
+    "s-874349590b87"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 17,
+     "uncertainties": 3
+    },
+    "ungated": {
+     "beliefs": 17,
+     "uncertainties": 3
+    }
+   },
+   "positions_changed": 4,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 4,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-54ae239c88dc": -1,
+       "s-874349590b87": -2,
+       "s-881099e29989": 2,
+       "s-9b4f7f1e1d7d": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:b465ffd080ec6e17",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789341804.0,
+   "n_flipped_items": 8,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "r-cd0c8950dc84",
+    "s-ed1cc815927c"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": false,
+    "ungated": false
+   },
+   "trimmed": {
+    "gated": {},
+    "ungated": {}
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-4e26d42f9eb7": 1,
+       "s-ed1cc815927c": -1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:d1a1db208ae75721",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789110419.0,
+   "n_flipped_items": 13,
+   "n_lid_biting_flips": 2,
+   "lid_biting_items": [
+    "o-a28fe6edb0dd",
+    "r-1156e3b268b0"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 14,
+     "uncertainties": 11,
+     "decisions": 3
+    },
+    "ungated": {
+     "beliefs": 14,
+     "uncertainties": 11,
+     "decisions": 3
+    }
+   },
+   "positions_changed": 2,
+   "cap_crossings": 0,
+   "differs": true,
+   "sections": {
+    "external": {
+     "positions_changed": 2,
+     "cap_crossings": {
+      "count": 0,
+      "only_gated": [],
+      "only_ungated": []
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "o-a28fe6edb0dd": -1,
+       "o-b13c228d0e1e": 1
+      }
+     }
+    }
+   }
+  },
+  {
+   "checkpoint": "sha256:8de4e14dc31eac2f",
+   "source": "local",
+   "horizon_days": 1,
+   "now": 1789196835.0,
+   "n_flipped_items": 12,
+   "n_lid_biting_flips": 3,
+   "lid_biting_items": [
+    "r-ee1054e42e0b",
+    "s-658b952291cc",
+    "s-db7a5f8f012a"
+   ],
+   "n_truncation_exempting_flips": 0,
+   "truncation_exempting_items": [],
+   "over_budget": {
+    "gated": true,
+    "ungated": true
+   },
+   "trimmed": {
+    "gated": {
+     "beliefs": 13
+    },
+    "ungated": {
+     "beliefs": 13
+    }
+   },
+   "positions_changed": 3,
+   "cap_crossings": 2,
+   "differs": true,
+   "sections": {
+    "beliefs": {
+     "positions_changed": 3,
+     "cap_crossings": {
+      "count": 2,
+      "only_gated": [
+       "s-d76f869b470c"
+      ],
+      "only_ungated": [
+       "s-db7a5f8f012a"
+      ]
+     },
+     "rank_diff": {
+      "identical": false,
+      "items_in": [],
+      "items_out": [],
+      "rank_deltas": {
+       "s-658b952291cc": -1,
+       "s-d76f869b470c": 2,
+       "s-db7a5f8f012a": -1
+      }
+     }
+    }
+   }
+  }
+ ]
+}

--- a/research/experiments/trust-gate-cost-976/replay.py
+++ b/research/experiments/trust-gate-cost-976/replay.py
@@ -1,0 +1,896 @@
+"""Trust-gate cost replay (#976): what the #408 lid costs `suggest` and the
+briefing's section order.
+
+#754 measured the trust gate on ONE surface (`recall.search`) and found it
+free: search does not rank on trust, so reverting every downgrade left the
+rankings byte-identical. That result says nothing about the two surfaces that
+DO rank on trust. Both reach it through `scoring.effective_weight`, which
+applies `trust_ceiling` LAST via `_soft_clip`:
+
+  suggest   `recall.suggest` ranks bm25 relevance x `_suggest_weight`, and
+            `_suggest_weight` is `effective_weight` plus the interval-slot
+            demotions. limit=2 in production; measured here at 2 and 5.
+  briefing  `briefing.build` sorts open_questions / strong_beliefs /
+            uncertainties by `effective_weight` (`_by_weight`); decisions stay
+            chronological. `briefing.render_plain` then drops whole items from
+            `_DROP_ORDER` tails until the token budget holds, so a weight
+            change can also decide who survives the budget.
+
+The mechanism bounds the answer in advance. `_soft_clip` is the IDENTITY below
+its knee K = C * (1 - _SOFT_CLIP_DELTA) and only compresses above it, so
+reverting a downgrade (inferred lid 0.7 -> verbatim lid 3.0) changes an item's
+weight only when the item's UNCAPPED accumulation already exceeds the inferred
+knee, 0.63. Call such a flip LID-BITING. Every other flip is arithmetically
+invisible on both surfaces.
+
+Registered predictions (frozen before the run, vault note
+`Design - Trust Gate Cost Experiment 2026-09-12`):
+
+  P1 (mechanism): every suggest or briefing difference between arms is
+  attributable to a lid-biting flipped item; where the lid-biting count is
+  zero, the arms are identical.
+
+  P2 (size): the lid-biting fraction of flipped items is small, single-digit
+  percent.
+
+Both were falsified; `measurements.json` carries the numbers. P1 failed on one
+briefing comparison whose difference traces to a SECOND channel the
+pre-registration did not name: `render_plain` stage 1 shortens oversized items
+except verbatim ones (#30), so a downgrade makes an item truncatable and BUYS
+budget, and lifting the gate costs a different item its place. See
+`is_truncation_exempting`, which the run added and the record reports beside
+the lid. P2 failed because the horizons anchor `now` to each checkpoint's own
+`created`, which keeps items fresh enough that a large minority clear the knee.
+
+Arms, exactly as in #754:
+
+  A gated    the stores as written
+  B ungated  every trust-gate downgrade reverted (`should_flip`, IMPORTED from
+             the #754 runner so both experiments share one predicate), trust
+             set back to `verbatim`, `recall.db` deleted, index rebuilt
+
+Substrates: the 54 questions of `benchmark/results/interim-317-baseline-first54
+.json` over their own `benchmark/.work/<qid>` stores (suggest), and every
+checkpoint in those stores plus the local `~/.daimon/checkpoints` store
+(briefing). Zero LLM calls; sessions are never re-serialized.
+
+Copy-on-read: the originals are never written. Both arms run against copies in
+a scratch dir, under an env where every DAIMON_* variable is redirected there.
+
+Privacy: no item text, quote or prompt text is recorded. Items are identified
+by their stamped id, or by a sha256 prefix of their text when a legacy
+checkpoint stamped none; local-store checkpoints by a sha256 prefix of their
+store-relative path.
+
+Run from the repo root:
+
+  cd plugin && DAIMON_BENCH_ROOT=<checkout holding benchmark/.work> \\
+      uv run python ../research/experiments/trust-gate-cost-976/replay.py
+
+`DAIMON_BENCH_ROOT` defaults to this checkout and only needs setting when the
+bench substrate (untracked) lives in another worktree. `DAIMON_LOCAL_STORE`
+overrides the local checkpoint store; set it empty to skip that arm.
+
+REPRODUCIBILITY: `~/.daimon/checkpoints` is LIVE. Any session running beside
+the replay appends checkpoints to it, so two passes over the live store read
+two different corpora and their outputs differ for reasons that have nothing
+to do with the code. The committed record was produced against a FROZEN copy:
+
+  cp -R ~/.daimon/checkpoints /some/scratch/snapshot
+  DAIMON_LOCAL_STORE=/some/scratch/snapshot ... uv run python .../replay.py
+
+`measurements.json` carries an `inputs` block fingerprinting exactly what was
+read, so a re-run can tell "the code changed" from "the store moved".
+"""
+
+import copy
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+REPO = _HERE.parents[3]
+PLUGIN = REPO / "plugin"
+sys.path.insert(0, str(PLUGIN))
+
+from daimon_briefing import briefing, recall, schema, scoring, store  # noqa: E402
+from tests.bench import dataset  # noqa: E402
+
+
+def _load_ungated_arm():
+    """The #754 runner, loaded BY PATH under its own module name.
+
+    Not `sys.path.insert` + `import replay`: both experiments' runners are
+    named `replay`, so a path import resolves to whichever landed in
+    sys.modules first — which, when this module is the one under test, is
+    this file, turning "we share the predicate" into a tautology.
+    """
+    path = _HERE.parent.parent / "ungated-arm" / "replay.py"
+    spec = importlib.util.spec_from_file_location("ungated_arm_replay", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging
+        raise SystemExit(f"cannot load the #754 runner at {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ungated_arm_replay"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+UNGATED_ARM = _load_ungated_arm()
+# ONE predicate across both experiments. #754's docstring carries the argument
+# for it: `quote_verified: false` and `grounded: false` are code-owned markers
+# no model output carries into a fresh item.
+should_flip = UNGATED_ARM.should_flip
+flip_downgrades = UNGATED_ARM.flip_downgrades
+
+BENCH_ROOT = Path(os.environ.get("DAIMON_BENCH_ROOT") or REPO)
+WORK = BENCH_ROOT / "benchmark" / ".work"
+DATA = BENCH_ROOT / "benchmark" / ".data" / dataset.DATASET_FILENAME
+REFERENCE = (BENCH_ROOT / "benchmark" / "results"
+             / "interim-317-baseline-first54.json")
+_LOCAL_RAW = os.environ.get("DAIMON_LOCAL_STORE")
+LOCAL_STORE = (Path(_LOCAL_RAW).expanduser() if _LOCAL_RAW is not None
+               else Path.home() / ".daimon" / "checkpoints")
+OUT = _HERE.parent / "measurements.json"
+
+DAY = 86400.0
+SUGGEST_LIMITS = (2, 5)          # production is 2; 5 widens the window
+BRIEFING_HORIZONS = (1, 30)      # days after the checkpoint's own `created`
+MIN_MESSAGES = 2                 # the reference run's bench floor
+
+# The sections briefing.build sorts by effective_weight. `decisions` is
+# deliberately absent: it stays chronological, so trust cannot reorder it —
+# it can still lose items to the budget, which the render diff covers.
+SORTED_SECTIONS = ("external", "open_loops", "beliefs", "uncertainties")
+_SECTION_TYPE = {
+    "external": "open_question",
+    "open_loops": "open_question",
+    "beliefs": "strong_belief",
+    "uncertainties": "uncertainty",
+    "decisions": "recent_decision",
+}
+RENDER_SECTIONS = SORTED_SECTIONS + ("decisions",)
+
+# Below this, _soft_clip is the identity for an inferred item, so reverting its
+# downgrade cannot move its weight by even a float ulp.
+LID_KNEE = scoring.trust_ceiling("inferred") * (1.0 - scoring._SOFT_CLIP_DELTA)
+
+_KEY_FIELD = "_replay_key"   # our identity stamp, carried through render copies
+
+
+# ---------------------------------------------------------------- pure logic
+
+def item_key(item: dict) -> str:
+    """One item's identity in the record: its stamped id, else a sha256 prefix
+    of its text. Never the text — the bench corpus is public but the local
+    store is not, and one record must be safe to commit whole."""
+    stamped = item.get("id")
+    if stamped:
+        return str(stamped)
+    text = str(item.get("text") or "")
+    return "h:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+
+
+def uncapped_weight(item: dict, item_type: str, now: float) -> float:
+    """The item's accumulation BEFORE the trust lid: importance x recency x
+    type decay x overdue boost.
+
+    Read from `scoring.explain`'s published `factors.raw` rather than
+    recomputed here. explain derives its factors independently of
+    effective_weight (its own docstring says so, and a test pins the factors to
+    their product), so this is the one lid-free number the shipping code
+    already stands behind. Recomputing the product in the runner would make the
+    diagnostic depend on a second copy of TYPE_RULES that no test guards.
+    """
+    return scoring.explain(item, item_type, now)["factors"]["raw"]
+
+
+def is_lid_biting(item: dict, item_type: str, now: float) -> bool:
+    """True when this item's accumulation clears the inferred knee, so a flip
+    of its trust class actually changes its effective weight. Reads the
+    uncapped product, so the answer is the same before and after the flip."""
+    return uncapped_weight(item, item_type, now) > LID_KNEE
+
+
+_DROP_ORDER_SECTIONS = frozenset(key for key, _end in briefing._DROP_ORDER)
+
+
+def is_truncation_exempting(item: dict, section: str) -> bool:
+    """True when flipping this item to verbatim changes the RENDERED LENGTH.
+
+    The SECOND channel trust reaches the briefing by, and the one the
+    pre-registration missed. `render_plain` stage 1 shortens oversized items
+    in place, EXCEPT verbatim ones, which #30 froze. So an item long enough to
+    be truncated buys its section budget while it is inferred and stops doing
+    so the moment the gate is lifted, and stage 2 has to drop somebody else.
+    This is independent of `effective_weight`: it moves no item's rank, it
+    changes who survives, and it points the OTHER way — the gate makes the
+    briefing hold MORE items, not fewer.
+
+    Asks the shipped truncator rather than comparing lengths:
+    `truncate_preserving_sections` may leave an over-cap text alone, and a
+    length proxy would then claim an effect the render does not have.
+    """
+    if section not in _DROP_ORDER_SECTIONS:
+        return False
+    text = str(item.get("text") or "")
+    return briefing.truncate_preserving_sections(
+        text, briefing._ITEM_TRUNCATE_CHARS) != text
+
+
+def rank_diff(gated: list, ungated: list) -> dict:
+    """Ordered-list diff between the two arms' results for one prompt."""
+    a_pos = {k: i for i, k in enumerate(gated)}
+    b_pos = {k: i for i, k in enumerate(ungated)}
+    shared = set(a_pos) & set(b_pos)
+    return {
+        "identical": list(gated) == list(ungated),
+        # `items_in` entered under the ungated arm; `items_out` left it.
+        "items_in": sorted(set(b_pos) - set(a_pos)),
+        "items_out": sorted(set(a_pos) - set(b_pos)),
+        # Positive = the item FELL when the gate was lifted.
+        "rank_deltas": {k: b_pos[k] - a_pos[k] for k in sorted(shared)
+                        if b_pos[k] != a_pos[k]},
+    }
+
+
+def positions_changed(gated: list, ungated: list) -> int:
+    """How many section slots hold a different item between the arms. A length
+    difference counts every orphan slot as changed — an item that vanished
+    from a position changed that position."""
+    return sum(
+        1 for i in range(max(len(gated), len(ungated)))
+        if (gated[i] if i < len(gated) else None)
+        != (ungated[i] if i < len(ungated) else None)
+    )
+
+
+def cap_crossings(gated: set, ungated: set) -> dict:
+    """Items that survived the render budget in one arm and not the other."""
+    only_gated = sorted(set(gated) - set(ungated))
+    only_ungated = sorted(set(ungated) - set(gated))
+    return {
+        "count": len(only_gated) + len(only_ungated),
+        "only_gated": only_gated,
+        "only_ungated": only_ungated,
+    }
+
+
+def fingerprint_files(entries) -> str:
+    """One digest over a set of (relative path, content sha256) pairs.
+
+    The local store is LIVE — other sessions append checkpoints to it while a
+    replay runs — so "re-run it and the bytes match" is a claim about the
+    RUNNER only once the inputs are pinned. This is what pins them: a record
+    whose fingerprint differs was measured over a different corpus, and its
+    numbers are not comparable, however identical the code.
+
+    Order-independent (the caller's read order is not part of the input) and
+    NUL-separated, so a rename cannot hide behind an edit. Emits one digest,
+    never the paths: local checkpoint paths name the operator's projects.
+    """
+    digest = hashlib.sha256()
+    for label, content in sorted(entries):
+        digest.update(label.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(content.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def fingerprint_store(root: Path) -> dict:
+    entries = [(str(p.relative_to(root)),
+                hashlib.sha256(p.read_bytes()).hexdigest())
+               for p in _checkpoint_files(root)]
+    return {"files": len(entries), "sha256": fingerprint_files(entries)}
+
+
+def wilson(k: int, n: int, z: float = 1.96) -> tuple:
+    """Wilson score interval for k successes in n trials.
+
+    Not the normal approximation: every fraction this runner reports is
+    expected near 0, where the Wald interval is nonsense (it collapses to a
+    point at k=0 and can leave the unit interval). n=0 returns the whole unit
+    interval, because no observations is no evidence — reporting (0, 0) there
+    would read as a MEASURED zero rate.
+    """
+    if n <= 0:
+        return (0.0, 1.0)
+    p = k / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p + z2 / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+# ------------------------------------------------------------- env / scratch
+
+class _Env:
+    """Redirect EVERY DAIMON_* variable at once, restoring on exit.
+
+    #754's `_Env` pops a hand-listed key tuple. A list is the wrong shape
+    here: this runner reads two more surfaces than #754 did (config's briefing
+    budget, decision cap and extra-read slugs all reach the measurement), and
+    a variable the list forgets is inherited silently from the operator's own
+    shell, which is how a replay quietly measures somebody's local config
+    instead of the code. The env FILE is neutralized the same way, by pointing
+    DAIMON_ENV_FILE at a path inside the scratch dir that does not exist —
+    config falls back to it whenever the process env has no value.
+    """
+
+    def __init__(self, mapping: dict):
+        self.mapping = mapping
+        self.saved: dict = {}
+
+    def __enter__(self):
+        self.saved = {k: v for k, v in os.environ.items()
+                      if k.startswith("DAIMON_")}
+        for k in self.saved:
+            os.environ.pop(k, None)
+        os.environ.update(self.mapping)
+        return self
+
+    def __exit__(self, *exc):
+        for k in [k for k in os.environ if k.startswith("DAIMON_")]:
+            os.environ.pop(k, None)
+        os.environ.update(self.saved)
+
+
+def _env_for(home: Path, project_dir: Path, extra_slugs=()) -> dict:
+    return {
+        "DAIMON_CHECKPOINT_DIR": str(home / "checkpoints"),
+        "DAIMON_RECALL_DB": str(home / "recall.db"),
+        "DAIMON_LOG_DIR": str(home / "logs"),
+        "DAIMON_RECALL_SEEN_DIR": str(home / "recall_seen"),
+        "DAIMON_TEAM_DIR": str(home / "team"),
+        "DAIMON_PROJECT_DIR": str(project_dir),
+        "DAIMON_ENV_FILE": str(home / "no-such-env-file"),
+        "DAIMON_CARRY": "0",
+        "DAIMON_MIN_MESSAGES": str(MIN_MESSAGES),
+        "DAIMON_TEAM": "0",
+        "DAIMON_DISABLE": "0",
+        "DAIMON_RECEIPTS": "0",
+        "DAIMON_SCAR_HARVEST": "0",
+        "DAIMON_SCENE_TRACES": "0",
+        "DAIMON_EXTRA_READ_SLUGS": ",".join(extra_slugs),
+    }
+
+
+# ------------------------------------------------------------- checkpoint io
+
+def _checkpoint_files(root: Path) -> list:
+    """Every checkpoint json under a store root, in a stable order."""
+    return sorted(p for p in root.rglob("*.json") if p.is_file())
+
+
+def _load_checkpoint(path: Path):
+    try:
+        cp = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return cp if isinstance(cp, dict) else None
+
+
+def _typed_items(checkpoint: dict):
+    """Yield (item, scoring type) for every scored item in a checkpoint.
+
+    Walks `schema.ITEM_FIELDS`, the single source both recall's index view and
+    carry's view derive from, so a field added there reaches this runner
+    without an edit. Fields with no scoring type (contradictions) are skipped:
+    nothing ranks them, so a flip there cannot move an order.
+    """
+    for field in schema.ITEM_FIELDS:
+        if not field.scoring_type:
+            continue
+        block = checkpoint.get(field.section)
+        if not isinstance(block, dict):
+            continue
+        if field.singleton:
+            item = block.get(field.key)
+            if isinstance(item, dict):
+                yield item, field.scoring_type
+            continue
+        for item in block.get(field.key) or []:
+            if isinstance(item, dict):
+                yield item, field.scoring_type
+
+
+def stamp_keys(checkpoint: dict) -> None:
+    """Stamp each item with its identity BEFORE any arm touches it.
+
+    render_plain's stage 1 rewrites `text` on non-verbatim items, so an
+    identity derived from text at render time would rename exactly the items
+    the budget squeezed. Stamped up front, the key rides through the `{**i}`
+    copy unchanged.
+    """
+    for item, _type in _typed_items(checkpoint):
+        item[_KEY_FIELD] = item_key(item)
+
+
+def _key_of(item: dict) -> str:
+    return str(item.get(_KEY_FIELD) or item_key(item))
+
+
+def flip_in_memory(checkpoint: dict) -> list:
+    """Revert every trust-gate downgrade in a checkpoint copy. Returns
+    [(key, scoring type, item-as-it-stood-before-the-flip)]."""
+    flipped = []
+    for item, item_type in _typed_items(checkpoint):
+        if should_flip(item):
+            flipped.append((_key_of(item), item_type, dict(item)))
+            item["trust"] = "verbatim"
+    return flipped
+
+
+# --------------------------------------------------------------- suggest arm
+
+def _stamped_slugs(home: Path) -> list:
+    """The project slugs the copied store's checkpoints carry.
+
+    A copied store keeps the slug stamped at capture, which names the ORIGINAL
+    path; the scratch project dir slugs to something else entirely. Without
+    this the ambient scope never covers the store and `suggest` returns [] on
+    every prompt — a broken instrument that looks exactly like a null result.
+    """
+    slugs = []
+    for path in _checkpoint_files(home / "checkpoints"):
+        cp = _load_checkpoint(path)
+        slug = (cp or {}).get("project_slug")
+        if slug and slug not in slugs:
+            slugs.append(slug)
+    return slugs
+
+
+def _newest_created(home: Path) -> float | None:
+    best = None
+    for path in _checkpoint_files(home / "checkpoints"):
+        cp = _load_checkpoint(path)
+        epoch = store._created_epoch((cp or {}).get("created"))
+        if epoch is not None and (best is None or epoch > best):
+            best = epoch
+    return best
+
+
+def _suggest_keys(rows: list) -> list:
+    return [item_key({"id": r.get("item_id"), "text": r.get("text")})
+            for r in rows]
+
+
+def run_suggest_arm(home: Path, project_dir: Path, prompt: str,
+                    now: float) -> dict:
+    """One arm's suggest results for one prompt, at every measured limit."""
+    with _Env(_env_for(home, project_dir, _stamped_slugs(home))):
+        recall.rebuild()
+        out = {}
+        for limit in SUGGEST_LIMITS:
+            rows = recall.suggest(prompt, project_dir=str(project_dir),
+                                  limit=limit, now=now)
+            out[limit] = {"keys": _suggest_keys(rows),
+                          "sessions": [r["session_id"] for r in rows],
+                          "kinds": [r.get("kind") for r in rows]}
+    return out
+
+
+def measure_suggest(scratch: Path) -> tuple:
+    """The suggest surface over the 54 reference-run bench stores."""
+    questions = {q["question_id"]: q for q in dataset.load(DATA)}
+    with open(REFERENCE, encoding="utf-8") as fh:
+        qids = [q["question_id"] for q in json.load(fh)["per_question"]]
+
+    rows, totals = [], {
+        "prompts": 0, "fired": 0, "identical": 0, "differing": 0,
+        "flipped_items": 0, "lid_biting_flips": 0,
+        "differences_with_a_lid_biting_flip": 0,
+    }
+    for n, qid in enumerate(qids, 1):
+        src = WORK / qid
+        if not src.is_dir():
+            raise SystemExit(f"{qid}: no .work store; run the bench first")
+        gated = scratch / "suggest" / qid / "gated"
+        ungated = scratch / "suggest" / qid / "ungated"
+        gated.parent.mkdir(parents=True, exist_ok=True)
+        for dst in (gated, ungated):
+            shutil.copytree(src, dst)
+        project_dir = scratch / "suggest" / qid / "project"
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        created = _newest_created(gated)
+        now = (created if created is not None else 0.0) + DAY
+        prompt = questions[qid]["question"]
+
+        # Classify the flips BEFORE the arm rewrites them on disk.
+        flips = []
+        for path in _checkpoint_files(gated / "checkpoints"):
+            cp = _load_checkpoint(path)
+            if cp is None:
+                continue
+            stamp_keys(cp)
+            for item, item_type in _typed_items(cp):
+                if should_flip(item):
+                    flips.append({"item": _key_of(item),
+                                  "lid_biting": is_lid_biting(item, item_type,
+                                                              now)})
+        lid_biting = {f["item"] for f in flips if f["lid_biting"]}
+
+        a = run_suggest_arm(gated, project_dir, prompt, now)
+        n_flipped = flip_downgrades(ungated)
+        b = run_suggest_arm(ungated, project_dir, prompt, now)
+
+        per_limit, differs, fired = {}, False, False
+        for limit in SUGGEST_LIMITS:
+            diff = rank_diff(a[limit]["keys"], b[limit]["keys"])
+            fired = fired or bool(a[limit]["keys"] or b[limit]["keys"])
+            differs = differs or not diff["identical"]
+            per_limit[str(limit)] = {
+                "n_gated": len(a[limit]["keys"]),
+                "n_ungated": len(b[limit]["keys"]),
+                **diff,
+            }
+
+        responsible = sorted(
+            {k for limit in SUGGEST_LIMITS
+             for k in (set(a[limit]["keys"]) ^ set(b[limit]["keys"]))
+             | set(rank_diff(a[limit]["keys"], b[limit]["keys"])["rank_deltas"])}
+        )
+        totals["prompts"] += 1
+        totals["fired"] += fired
+        totals["identical"] += not differs
+        totals["differing"] += differs
+        totals["flipped_items"] += n_flipped
+        totals["lid_biting_flips"] += len(lid_biting)
+        if differs and lid_biting:
+            totals["differences_with_a_lid_biting_flip"] += 1
+
+        rows.append({
+            "question_id": qid,
+            "now": now,
+            "fired": fired,
+            "identical": not differs,
+            "n_flipped_items": n_flipped,
+            "n_lid_biting_flips": len(lid_biting),
+            "by_limit": per_limit,
+            # Only the items that actually moved, each with the reason the
+            # mechanism allows: was it a flip that clears the knee?
+            "responsible": [
+                {"item": k, "flipped": k in {f["item"] for f in flips},
+                 "lid_biting": k in lid_biting}
+                for k in responsible
+            ],
+        })
+        print(f"[{n:2d}/{len(qids)}] {qid} fired={fired} "
+              f"identical={not differs} flips={n_flipped} "
+              f"lid_biting={len(lid_biting)}", flush=True)
+        shutil.rmtree(scratch / "suggest" / qid, ignore_errors=True)
+    return rows, totals
+
+
+# -------------------------------------------------------------- briefing arm
+
+def _render_survivors(b: dict) -> tuple:
+    """Which items survive `render_plain`'s budget, and whether it bit.
+
+    Observed rather than re-derived: `briefing._render_parts` is wrapped so the
+    LAST call render_plain makes is captured, and that call's `b` IS the
+    section state behind the returned text (every `text` in render_plain is
+    assigned from a _render_parts return). Reimplementing the stage-2 drop loop
+    in the runner would put a second copy of the budget policy in the
+    measurement, free to drift from the one being measured.
+    """
+    calls = []
+    original = briefing._render_parts
+
+    def spy(section_state, trimmed, *args, **kwargs):
+        calls.append((section_state, dict(trimmed)))
+        return original(section_state, trimmed, *args, **kwargs)
+
+    briefing._render_parts = spy
+    try:
+        briefing.render_plain(b)
+    finally:
+        briefing._render_parts = original
+
+    final_state, trimmed = calls[-1]
+    survivors = {
+        key: {_key_of(i) for i in (final_state.get(key) or [])}
+        for key in RENDER_SECTIONS
+    }
+    return survivors, {"over_budget": len(calls) > 1,
+                       "trimmed": {k: v for k, v in trimmed.items() if v}}
+
+
+def measure_one_checkpoint(cp: dict, label: str, source: str) -> list:
+    """Both arms of one checkpoint at every horizon. Returns the differing
+    rows only; callers aggregate the rest."""
+    created = store._created_epoch(cp.get("created"))
+    if created is None:
+        return [{"checkpoint": label, "source": source, "skipped": "no created stamp"}]
+
+    stamp_keys(cp)
+    out = []
+    for horizon in BRIEFING_HORIZONS:
+        now = created + horizon * DAY
+        gated_cp = copy.deepcopy(cp)
+        ungated_cp = copy.deepcopy(cp)
+        flipped = flip_in_memory(ungated_cp)
+        lid_biting = sorted({key for key, item_type, before in flipped
+                             if is_lid_biting(before, item_type, now)})
+
+        a = briefing.build(gated_cp, now=now)
+        b = briefing.build(ungated_cp, now=now)
+        row = {
+            "checkpoint": label,
+            "source": source,
+            "horizon_days": horizon,
+            "now": now,
+            "n_flipped_items": len(flipped),
+            "n_lid_biting_flips": len(lid_biting),
+            "lid_biting_items": lid_biting,
+        }
+        if a is None and b is None:
+            row["empty"] = True
+            out.append(row)
+            continue
+
+        order_a = {k: [_key_of(i) for i in (a.get(k) or [])]
+                   for k in SORTED_SECTIONS}
+        order_b = {k: [_key_of(i) for i in (b.get(k) or [])]
+                   for k in SORTED_SECTIONS}
+        survivors_a, budget_a = _render_survivors(a)
+        survivors_b, budget_b = _render_survivors(b)
+
+        flipped_keys = {key for key, _t, _before in flipped}
+        exempting = sorted({
+            _key_of(i)
+            for key in RENDER_SECTIONS if key in _DROP_ORDER_SECTIONS
+            for i in (a.get(key) or [])
+            if _key_of(i) in flipped_keys and is_truncation_exempting(i, key)})
+        row["n_truncation_exempting_flips"] = len(exempting)
+        row["truncation_exempting_items"] = exempting
+
+        sections = {}
+        for key in RENDER_SECTIONS:
+            entry = {
+                "positions_changed": (
+                    positions_changed(order_a[key], order_b[key])
+                    if key in SORTED_SECTIONS else 0),
+                "cap_crossings": cap_crossings(survivors_a[key],
+                                               survivors_b[key]),
+            }
+            if key in SORTED_SECTIONS:
+                entry["rank_diff"] = rank_diff(order_a[key], order_b[key])
+            sections[key] = entry
+
+        row["over_budget"] = {"gated": budget_a["over_budget"],
+                              "ungated": budget_b["over_budget"]}
+        row["trimmed"] = {"gated": budget_a["trimmed"],
+                          "ungated": budget_b["trimmed"]}
+        row["positions_changed"] = sum(s["positions_changed"]
+                                       for s in sections.values())
+        row["cap_crossings"] = sum(s["cap_crossings"]["count"]
+                                   for s in sections.values())
+        row["differs"] = bool(row["positions_changed"] or row["cap_crossings"])
+        row["sections"] = {k: v for k, v in sections.items()
+                           if v["positions_changed"] or v["cap_crossings"]["count"]}
+        out.append(row)
+    return out
+
+
+def measure_briefing(scratch: Path) -> tuple:
+    """The briefing surface over the bench stores plus the local store."""
+    with open(REFERENCE, encoding="utf-8") as fh:
+        qids = [q["question_id"] for q in json.load(fh)["per_question"]]
+
+    # Copy-on-read, as in #754: nothing here writes, but the originals are the
+    # only copy of both substrates and a runner that reads them in place is one
+    # edit away from being a runner that does not.
+    sources = []
+    for qid in qids:
+        sources.append((f"bench:{qid}", WORK / qid / "checkpoints",
+                        lambda p, root, qid=qid: f"{qid}/{p.name}"))
+    if LOCAL_STORE and LOCAL_STORE.is_dir():
+        sources.append((
+            "local", LOCAL_STORE,
+            lambda p, root: "sha256:" + hashlib.sha256(
+                str(p.relative_to(root)).encode("utf-8")).hexdigest()[:16]))
+
+    rows, totals = [], {
+        "checkpoints": 0, "measured": 0, "skipped_no_created": 0,
+        "empty": 0, "comparisons": 0, "differing": 0,
+        "differences_with_a_lid_biting_flip": 0,
+        "differences_with_a_truncation_exempting_flip": 0,
+        "differences_with_neither_channel": 0,
+        "flipped_items": 0, "lid_biting_flips": 0,
+        "truncation_exempting_flips": 0,
+        "positions_changed": 0, "cap_crossings": 0, "over_budget": 0,
+    }
+    by_horizon = {h: {"flips": 0, "lid_biting": 0} for h in BRIEFING_HORIZONS}
+    inputs = {"bench": {"stores": len(qids), "files": 0, "sha256": ""},
+              "local": {"present": False}}
+    bench_digests: list = []
+    project_dir = scratch / "briefing-project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    home = scratch / "briefing-home"
+    (home / "checkpoints").mkdir(parents=True, exist_ok=True)
+
+    # The briefing arm only READS checkpoint dicts, but build/render still ask
+    # config for the decision cap and the token budget, so it runs under the
+    # same redirected env as the suggest arm: the numbers must come from the
+    # shipped defaults, not from whatever the operator's shell exports.
+    with _Env(_env_for(home, project_dir)):
+        for source, origin, labeller in sources:
+            if not origin.is_dir():
+                continue
+            root = scratch / "briefing-src" / source.replace(":", "-")
+            root.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(origin, root)
+            # Fingerprint the COPY, not the origin: the local store is live,
+            # and a fingerprint taken before the copy could name a corpus the
+            # run never read.
+            fp = fingerprint_store(root)
+            if source == "local":
+                inputs["local"] = {"present": True, **fp}
+            else:
+                bench_digests.append((source, fp["sha256"]))
+                inputs["bench"]["files"] += fp["files"]
+            for path in _checkpoint_files(root):
+                cp = _load_checkpoint(path)
+                totals["checkpoints"] += 1
+                if cp is None:
+                    continue
+                for row in measure_one_checkpoint(cp, labeller(path, root),
+                                                  source):
+                    if row.get("skipped"):
+                        totals["skipped_no_created"] += 1
+                        continue
+                    totals["comparisons"] += 1
+                    totals["flipped_items"] += row["n_flipped_items"]
+                    totals["lid_biting_flips"] += row["n_lid_biting_flips"]
+                    horizon = by_horizon[row["horizon_days"]]
+                    horizon["flips"] += row["n_flipped_items"]
+                    horizon["lid_biting"] += row["n_lid_biting_flips"]
+                    if row.get("empty"):
+                        totals["empty"] += 1
+                        continue
+                    totals["measured"] += 1
+                    totals["truncation_exempting_flips"] += row[
+                        "n_truncation_exempting_flips"]
+                    totals["over_budget"] += bool(
+                        row["over_budget"]["gated"]
+                        or row["over_budget"]["ungated"])
+                    totals["positions_changed"] += row["positions_changed"]
+                    totals["cap_crossings"] += row["cap_crossings"]
+                    if row["differs"]:
+                        totals["differing"] += 1
+                        if row["n_lid_biting_flips"]:
+                            totals[
+                                "differences_with_a_lid_biting_flip"] += 1
+                        if row["n_truncation_exempting_flips"]:
+                            totals[
+                                "differences_with_a_truncation_exempting_flip"
+                            ] += 1
+                        if not (row["n_lid_biting_flips"]
+                                or row["n_truncation_exempting_flips"]):
+                            totals["differences_with_neither_channel"] += 1
+                        # Per-checkpoint rows are kept for DIFFERING
+                        # comparisons only; the rest are in the totals. The
+                        # record has to stay small enough to commit.
+                        rows.append(row)
+            shutil.rmtree(root, ignore_errors=True)
+            print(f"  {source}: {totals['checkpoints']} checkpoints seen, "
+                  f"{totals['differing']} differing", flush=True)
+    totals["by_horizon"] = {str(h): v for h, v in by_horizon.items()}
+    inputs["bench"]["sha256"] = fingerprint_files(bench_digests)
+    return rows, totals, inputs
+
+
+# -------------------------------------------------------------------- report
+
+def _fraction(k: int, n: int) -> dict:
+    lo, hi = wilson(k, n)
+    return {"k": k, "n": n,
+            "rate": round(k / n, 6) if n else None,
+            "wilson95": [round(lo, 6), round(hi, 6)]}
+
+
+def main():
+    scratch = Path(tempfile.mkdtemp(prefix="trust-gate-cost-976-"))
+    try:
+        print("suggest arm:", flush=True)
+        suggest_rows, suggest_totals = measure_suggest(scratch)
+        print("briefing arm:", flush=True)
+        briefing_rows, briefing_totals, inputs = measure_briefing(scratch)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    flips = suggest_totals["flipped_items"] + briefing_totals["flipped_items"]
+    biting = (suggest_totals["lid_biting_flips"]
+              + briefing_totals["lid_biting_flips"])
+    suggest_diff = suggest_totals["differing"]
+    briefing_diff = briefing_totals["differing"]
+    p1 = (suggest_diff == suggest_totals["differences_with_a_lid_biting_flip"]
+          and briefing_diff
+          == briefing_totals["differences_with_a_lid_biting_flip"])
+    # The registered P1 named ONE channel. Held against both measured channels
+    # it is the claim that no difference is unexplained; reported separately so
+    # the falsification of the registered wording stays on the record.
+    unexplained = briefing_totals["differences_with_neither_channel"]
+    lid_fraction = _fraction(biting, flips)
+    p2 = bool(flips) and lid_fraction["wilson95"][1] < 0.10
+
+    summary = {
+        "suggest": {
+            "prompts": suggest_totals["prompts"],
+            "fired": _fraction(suggest_totals["fired"],
+                               suggest_totals["prompts"]),
+            "differing": _fraction(suggest_diff, suggest_totals["prompts"]),
+            "flipped_items": suggest_totals["flipped_items"],
+            "lid_biting_flips": suggest_totals["lid_biting_flips"],
+            "differences_with_a_lid_biting_flip":
+                suggest_totals["differences_with_a_lid_biting_flip"],
+            "limits": list(SUGGEST_LIMITS),
+        },
+        "briefing": {
+            "checkpoints": briefing_totals["checkpoints"],
+            "comparisons": briefing_totals["comparisons"],
+            "measured": briefing_totals["measured"],
+            "empty": briefing_totals["empty"],
+            "skipped_no_created": briefing_totals["skipped_no_created"],
+            "over_budget": _fraction(briefing_totals["over_budget"],
+                                     briefing_totals["measured"]),
+            "differing": _fraction(briefing_diff,
+                                   briefing_totals["measured"]),
+            "positions_changed": briefing_totals["positions_changed"],
+            "cap_crossings": briefing_totals["cap_crossings"],
+            "flipped_items": briefing_totals["flipped_items"],
+            "lid_biting_flips": briefing_totals["lid_biting_flips"],
+            "differences_with_a_lid_biting_flip":
+                briefing_totals["differences_with_a_lid_biting_flip"],
+            "truncation_exempting_flips":
+                briefing_totals["truncation_exempting_flips"],
+            "differences_with_a_truncation_exempting_flip":
+                briefing_totals[
+                    "differences_with_a_truncation_exempting_flip"],
+            "differences_with_neither_channel": unexplained,
+            "horizons_days": list(BRIEFING_HORIZONS),
+            # Per horizon, because a flip is counted once per horizon: the
+            # pooled rate below mixes two observations of the same item.
+            "by_horizon": {
+                h: {**v, "lid_biting_fraction":
+                    _fraction(v["lid_biting"], v["flips"])}
+                for h, v in briefing_totals["by_horizon"].items()},
+        },
+        "lid_knee": LID_KNEE,
+        "lid_biting_fraction_of_flips": lid_fraction,
+        "lid_biting_fraction_by_surface": {
+            "suggest": _fraction(suggest_totals["lid_biting_flips"],
+                                 suggest_totals["flipped_items"]),
+            "briefing": _fraction(briefing_totals["lid_biting_flips"],
+                                  briefing_totals["flipped_items"]),
+        },
+        "P1_every_difference_traces_to_a_lid_biting_flip": p1,
+        "P1_every_difference_traces_to_a_measured_channel": unexplained == 0,
+        "P2_lid_biting_fraction_is_single_digit_percent": p2,
+    }
+
+    OUT.write_text(json.dumps({
+        "issue": 976,
+        "pre_registration": "Design - Trust Gate Cost Experiment 2026-09-12",
+        # Which corpus produced these numbers. A re-run whose fingerprints
+        # differ read a different store and its numbers are not comparable.
+        "inputs": inputs,
+        "summary": summary,
+        "suggest": suggest_rows,
+        "briefing": briefing_rows,
+    }, indent=1, sort_keys=False), encoding="utf-8")
+    print("summary:", json.dumps(summary, indent=1))
+    print("wrote", OUT)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/trust-gate-cost-976/replay.py
+++ b/research/experiments/trust-gate-cost-976/replay.py
@@ -57,10 +57,13 @@ checkpoint in those stores plus the local `~/.daimon/checkpoints` store
 Copy-on-read: the originals are never written. Both arms run against copies in
 a scratch dir, under an env where every DAIMON_* variable is redirected there.
 
-Privacy: no item text, quote or prompt text is recorded. Items are identified
-by their stamped id, or by a sha256 prefix of their text when a legacy
-checkpoint stamped none; local-store checkpoints by a sha256 prefix of their
-store-relative path.
+Privacy: no item text, quote or prompt text is recorded, and no identifier is
+recorded in the clear. Every item is named by 16 hex of a sha256 over its
+stamped id, or over its text when a legacy checkpoint stamped none; a stamped
+id is itself an internal handle for a private store, so it is hashed like the
+text rather than published. Local-store checkpoints are named by a sha256
+prefix of their store-relative path. Bench question ids and bench session ids
+stay in the clear: that dataset is public and #754 committed them.
 
 Run from the repo root:
 
@@ -166,14 +169,26 @@ _KEY_FIELD = "_replay_key"   # our identity stamp, carried through render copies
 # ---------------------------------------------------------------- pure logic
 
 def item_key(item: dict) -> str:
-    """One item's identity in the record: its stamped id, else a sha256 prefix
-    of its text. Never the text — the bench corpus is public but the local
-    store is not, and one record must be safe to commit whole."""
+    """One item's identity in the record: 16 hex of a sha256, never the item.
+
+    Hashes the STAMPED ID as well as the text. A daimon item id is the handle
+    every local surface addresses that item by (`daimon resolve <id>`, the
+    amendment ledger, a supersedes link), so publishing one in a committed
+    file publishes an internal identifier for a private store, not an
+    anonymous label. An earlier pass of this record emitted 85 of them and the
+    voice gate refused the file.
+
+    Bench and local rows therefore share ONE shape, which is also what makes
+    the record readable: a 16-hex token means the same thing everywhere, and
+    no reader has to know which substrate a row came from to know whether the
+    identifier is safe to quote. The id and text domains are separated inside
+    the hash so the two namespaces cannot collide onto one key.
+    """
     stamped = item.get("id")
-    if stamped:
-        return str(stamped)
-    text = str(item.get("text") or "")
-    return "h:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    domain, raw = (("id", str(stamped)) if stamped
+                   else ("text", str(item.get("text") or "")))
+    payload = f"{domain}\0{raw}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
 
 
 def uncapped_weight(item: dict, item_type: str, now: float) -> float:

--- a/research/experiments/trust-gate-cost-976/test_replay.py
+++ b/research/experiments/trust-gate-cost-976/test_replay.py
@@ -1,0 +1,298 @@
+"""Unit tests for the pure logic in replay.py (#976). Run:
+
+  cd plugin && uv run --extra dev pytest ../research/experiments/trust-gate-cost-976/ -q
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "plugin"))
+
+from daimon_briefing import briefing, scoring  # noqa: E402
+
+from replay import (  # noqa: E402
+    LID_KNEE,
+    UNGATED_ARM,
+    cap_crossings,
+    fingerprint_files,
+    is_lid_biting,
+    is_truncation_exempting,
+    item_key,
+    positions_changed,
+    rank_diff,
+    should_flip,
+    uncapped_weight,
+    wilson,
+)
+
+
+# ---- the flip predicate is REUSED from #754, not re-implemented ----
+
+def test_flip_predicate_is_the_same_object_as_the_754_runner():
+    # Both experiments must share ONE predicate: a second definition that
+    # drifts would make the two measurements answer different questions.
+    # UNGATED_ARM is loaded BY PATH, so this is not the tautology a plain
+    # `import replay` would give (both runners are named `replay`).
+    expected = (Path(__file__).resolve().parents[1] / "ungated-arm"
+                / "replay.py")
+    assert Path(UNGATED_ARM.__file__) == expected
+    assert should_flip is UNGATED_ARM.should_flip
+
+
+def test_flip_predicate_still_targets_only_code_owned_downgrades():
+    assert should_flip({"trust": "inferred", "quote_verified": False})
+    assert should_flip({"trust": "inferred", "grounded": False})
+    assert not should_flip({"trust": "inferred"})
+    assert not should_flip({"trust": "verbatim", "quote_verified": True})
+
+
+# ---- item identity (privacy: never the text itself) ----
+
+def test_item_key_prefers_the_stamped_id():
+    assert item_key({"id": "q-abc123", "text": "anything"}) == "q-abc123"
+
+
+def test_item_key_hashes_the_text_when_no_id_is_stamped():
+    k = item_key({"text": "a bench item with no stamped id"})
+    assert k.startswith("h:")
+    assert len(k) == 14
+    assert "bench" not in k
+
+
+def test_item_key_is_stable_and_distinguishes_items():
+    a = {"text": "one"}
+    assert item_key(a) == item_key({"text": "one"})
+    assert item_key(a) != item_key({"text": "two"})
+
+
+# ---- the uncapped (lid-removed) weight ----
+
+def test_uncapped_weight_equals_effective_weight_below_the_knee():
+    # The identity region: _soft_clip is the identity at or below K, so the
+    # lid-removed product and the shipped ordering key must AGREE there. If
+    # they disagree, the lid-biting diagnostic is measuring the wrong number.
+    now = 1_700_000_000.0
+    shapes = [
+        # fresh, low importance, inferred: base 0.3 x recency 1.0 x decay
+        ({"trust": "inferred", "importance": 3,
+          "first_seen": "2023-11-14T22:13:20Z"}, "recent_decision"),
+        # unstamped first_seen: neutral recency, no decay, no escalation
+        ({"trust": "inferred", "importance": 5}, "strong_belief"),
+        # old verbatim: recency 0.2 x floored decay, far under the inferred knee
+        ({"trust": "verbatim", "importance": 6,
+          "first_seen": "2022-11-14T22:13:20Z"}, "uncertainty"),
+    ]
+    for item, item_type in shapes:
+        raw = uncapped_weight(item, item_type, now)
+        assert raw <= LID_KNEE, (item_type, raw)
+        assert raw == scoring.effective_weight(item, item_type, now)
+
+
+def test_uncapped_weight_exceeds_effective_weight_above_the_knee():
+    # A fresh, high-importance inferred item: the accumulation clears the
+    # inferred lid, so the shipped key is clipped and the raw product is not.
+    now = 1_700_000_000.0
+    item = {"trust": "inferred", "importance": 10,
+            "first_seen": "2023-11-14T22:13:20Z"}
+    raw = uncapped_weight(item, "recent_decision", now)
+    assert raw > LID_KNEE
+    assert raw > scoring.effective_weight(item, "recent_decision", now)
+
+
+def test_lid_knee_is_the_inferred_ceiling_soft_clip_knee():
+    assert LID_KNEE == scoring.trust_ceiling("inferred") * (
+        1.0 - scoring._SOFT_CLIP_DELTA)
+
+
+# ---- lid-biting classification ----
+
+def test_a_flip_below_the_knee_is_not_lid_biting():
+    now = 1_700_000_000.0
+    item = {"trust": "inferred", "importance": 2,
+            "first_seen": "2023-11-14T22:13:20Z"}
+    assert not is_lid_biting(item, "recent_decision", now)
+
+
+def test_a_flip_above_the_knee_is_lid_biting():
+    now = 1_700_000_000.0
+    item = {"trust": "inferred", "importance": 10,
+            "first_seen": "2023-11-14T22:13:20Z"}
+    assert is_lid_biting(item, "recent_decision", now)
+
+
+def test_lid_biting_reads_the_uncapped_product_not_the_stored_trust():
+    # The item is asked about as it stands BEFORE the flip (trust=inferred);
+    # the classification must not depend on having already rewritten trust.
+    now = 1_700_000_000.0
+    inferred = {"trust": "inferred", "importance": 9,
+                "first_seen": "2023-11-14T22:13:20Z"}
+    flipped = {**inferred, "trust": "verbatim"}
+    assert is_lid_biting(inferred, "open_question", now) == is_lid_biting(
+        flipped, "open_question", now)
+
+
+# ---- the SECOND channel: render_plain's verbatim truncation exemption ----
+#
+# Found by the run, not predicted by it. Stage 1 of render_plain shortens
+# oversized items in place EXCEPT verbatim ones (#30), so flipping an item to
+# verbatim can make the render LONGER and cost a different item its place in
+# the budget — a trust effect that never touches effective_weight.
+
+def test_a_long_item_in_a_droppable_section_is_truncation_exempting():
+    item = {"text": "x" * (briefing._ITEM_TRUNCATE_CHARS + 200)}
+    assert is_truncation_exempting(item, "decisions")
+    assert is_truncation_exempting(item, "beliefs")
+
+
+def test_a_short_item_is_never_truncation_exempting():
+    assert not is_truncation_exempting({"text": "short"}, "decisions")
+
+
+def test_a_long_item_outside_the_drop_order_is_not_truncation_exempting():
+    # `external` renders outside _DROP_ORDER, so stage 1 never rewrites it and
+    # its trust class cannot change the rendered length.
+    item = {"text": "x" * (briefing._ITEM_TRUNCATE_CHARS + 200)}
+    assert not is_truncation_exempting(item, "external")
+
+
+def test_truncation_exempting_asks_the_shipped_truncator():
+    # The predicate must be "would render actually shorten this", not a length
+    # comparison of the runner's own: truncate_preserving_sections may leave a
+    # text over the cap alone, and a length proxy would then claim an effect
+    # the render never has.
+    cap = briefing._ITEM_TRUNCATE_CHARS
+    for text in ("y" * (cap + 1), "y" * (cap * 3), "z" * (cap - 1)):
+        item = {"text": text}
+        shortens = briefing.truncate_preserving_sections(text, cap) != text
+        assert is_truncation_exempting(item, "uncertainties") is shortens
+
+
+# ---- ranked set / order diff ----
+
+def test_rank_diff_reports_identity():
+    d = rank_diff(["a", "b"], ["a", "b"])
+    assert d["identical"] is True
+    assert d["items_in"] == [] and d["items_out"] == []
+    assert d["rank_deltas"] == {}
+
+
+def test_rank_diff_reports_membership_changes():
+    d = rank_diff(["a", "b"], ["b", "c"])
+    assert d["identical"] is False
+    assert d["items_in"] == ["c"]      # present in the ungated arm only
+    assert d["items_out"] == ["a"]     # present in the gated arm only
+
+
+def test_rank_diff_reports_per_item_rank_movement_for_shared_items():
+    # "a" falls from rank 1 to rank 3, "c" climbs from rank 3 to rank 1.
+    d = rank_diff(["a", "b", "c"], ["c", "b", "a"])
+    assert d["rank_deltas"] == {"a": 2, "c": -2}
+    assert "b" not in d["rank_deltas"]
+
+
+def test_rank_diff_ignores_items_missing_from_one_arm_in_the_deltas():
+    d = rank_diff(["a", "b"], ["b"])
+    assert d["rank_deltas"] == {"b": -1}
+
+
+# ---- section position diff ----
+
+def test_positions_changed_counts_indices_that_differ():
+    assert positions_changed(["a", "b", "c"], ["a", "c", "b"]) == 2
+
+
+def test_positions_changed_is_zero_for_equal_sections():
+    assert positions_changed(["a", "b"], ["a", "b"]) == 0
+    assert positions_changed([], []) == 0
+
+
+def test_positions_changed_counts_length_differences_as_changed():
+    assert positions_changed(["a", "b"], ["a"]) == 1
+    assert positions_changed(["a"], ["a", "b"]) == 1
+
+
+# ---- cap crossings ----
+
+def test_cap_crossings_is_empty_when_both_arms_render_the_same_items():
+    c = cap_crossings({"a", "b"}, {"a", "b"})
+    assert c == {"count": 0, "only_gated": [], "only_ungated": []}
+
+
+def test_cap_crossings_names_the_items_each_arm_kept_alone():
+    c = cap_crossings({"a", "b"}, {"b", "c"})
+    assert c["count"] == 2
+    assert c["only_gated"] == ["a"]
+    assert c["only_ungated"] == ["c"]
+
+
+def test_cap_crossings_sorts_so_the_record_is_byte_stable():
+    c = cap_crossings({"z", "y", "x"}, set())
+    assert c["only_gated"] == ["x", "y", "z"]
+
+
+# ---- input fingerprint ----
+#
+# The local store is LIVE: other sessions write checkpoints into it while the
+# replay runs, so "re-run it and the bytes match" is only a determinism claim
+# once the inputs are pinned. The fingerprint is what pins them.
+
+def test_fingerprint_is_a_sha256_hex_digest():
+    fp = fingerprint_files([("a.json", "00" * 32)])
+    assert len(fp) == 64
+    assert set(fp) <= set("0123456789abcdef")
+
+
+def test_fingerprint_ignores_the_order_files_were_read_in():
+    a = ("a.json", "11" * 32)
+    b = ("b.json", "22" * 32)
+    assert fingerprint_files([a, b]) == fingerprint_files([b, a])
+
+
+def test_fingerprint_changes_when_a_file_changes():
+    assert (fingerprint_files([("a.json", "11" * 32)])
+            != fingerprint_files([("a.json", "22" * 32)]))
+
+
+def test_fingerprint_changes_when_a_file_is_renamed():
+    assert (fingerprint_files([("a.json", "11" * 32)])
+            != fingerprint_files([("b.json", "11" * 32)]))
+
+
+def test_fingerprint_changes_when_a_file_is_added():
+    one = [("a.json", "11" * 32)]
+    assert fingerprint_files(one) != fingerprint_files(
+        one + [("b.json", "22" * 32)])
+
+
+def test_fingerprint_separates_the_name_from_the_digest():
+    # Without a separator, ("ab", "c") and ("a", "bc") would collide and a
+    # rename could hide behind an edit.
+    assert (fingerprint_files([("ab", "c")])
+            != fingerprint_files([("a", "bc")]))
+
+
+# ---- Wilson score interval ----
+
+def test_wilson_matches_published_value_for_one_of_one():
+    lo, hi = wilson(1, 1)
+    assert round(lo, 4) == 0.2065
+    assert round(hi, 4) == 1.0
+
+
+def test_wilson_matches_published_value_for_five_of_ten():
+    lo, hi = wilson(5, 10)
+    assert round(lo, 4) == 0.2366
+    assert round(hi, 4) == 0.7634
+
+
+def test_wilson_of_an_empty_denominator_is_the_whole_unit_interval():
+    # No observations means no evidence, which is [0, 1] — never (0, 0),
+    # which would read as a measured zero rate.
+    assert wilson(0, 0) == (0.0, 1.0)
+
+
+def test_wilson_bounds_stay_inside_the_unit_interval():
+    for k, n in ((0, 10), (10, 10), (1, 3)):
+        lo, hi = wilson(k, n)
+        assert 0.0 <= lo <= hi <= 1.0

--- a/research/experiments/trust-gate-cost-976/test_replay.py
+++ b/research/experiments/trust-gate-cost-976/test_replay.py
@@ -47,17 +47,48 @@ def test_flip_predicate_still_targets_only_code_owned_downgrades():
     assert not should_flip({"trust": "verbatim", "quote_verified": True})
 
 
-# ---- item identity (privacy: never the text itself) ----
+# ---- item identity (privacy: never the text, never the stamped id) ----
 
-def test_item_key_prefers_the_stamped_id():
-    assert item_key({"id": "q-abc123", "text": "anything"}) == "q-abc123"
+def test_item_key_hashes_the_stamped_id_rather_than_publishing_it():
+    # A stamped id is the handle every local surface addresses the item by, so
+    # it is an internal identifier, not an anonymous label.
+    k = item_key({"id": "o-bdb0fd592ff3", "text": "anything"})
+    assert k != "o-bdb0fd592ff3"
+    assert "o-bdb0fd592ff3" not in k
+    assert k == item_key({"id": "o-bdb0fd592ff3"})
 
 
 def test_item_key_hashes_the_text_when_no_id_is_stamped():
     k = item_key({"text": "a bench item with no stamped id"})
-    assert k.startswith("h:")
-    assert len(k) == 14
     assert "bench" not in k
+
+
+def test_item_key_is_sixteen_hex_for_stamped_and_unstamped_items_alike():
+    # ONE shape across both substrates: a reader must not have to know which
+    # store a row came from to know whether its identifier is safe to quote.
+    for item in ({"id": "q-abc123", "text": "t"}, {"text": "t"}):
+        k = item_key(item)
+        assert len(k) == 16
+        assert set(k) <= set("0123456789abcdef")
+
+
+def test_item_key_never_returns_a_daimon_item_id_shape():
+    # The voice gate refuses `o-`/`q-`/`d-` prefixed handles in a public file.
+    # A hex digest carries no hyphen at all, which makes that true by
+    # construction rather than by luck.
+    for stamped in ("o-bdb0fd592ff3", "q-515dbfd4d77e", "d-bf54b43c19c1",
+                    "r-5f6ff1", "s-85df72", "u-58ea51"):
+        k = item_key({"id": stamped})
+        assert not k.startswith(("o-", "q-", "d-"))
+        assert "-" not in k
+        assert stamped not in k
+        assert stamped.split("-", 1)[1] not in k
+
+
+def test_item_key_separates_the_id_and_text_domains():
+    # Hashing a bare value would let an item whose TEXT is "x" collide with an
+    # item whose ID is "x", merging two different items onto one key.
+    assert item_key({"id": "x"}) != item_key({"text": "x"})
 
 
 def test_item_key_is_stable_and_distinguishes_items():


### PR DESCRIPTION
Closes #976

## What

A replay measurement in the shape of the #754 runner, zero LLM calls, copy
on read, committed under `research/experiments/trust-gate-cost-976/` as a
runner, its unit tests and a results file, so it can be re-run when either
surface changes. Two arms, exactly as #754: the stores as written, and the
same stores with every trust-gate downgrade reverted through the predicate
imported from the #754 runner, so both experiments share one definition of
a flip.

Substrates: the 54 frozen bench questions as prompts over their own stores
for `suggest`, at limit 2 (production) and 5; every checkpoint in those
stores plus a frozen snapshot of my local store for briefing order, at two
horizons anchored to each checkpoint's own creation time, one day and
thirty days. No item text, quote or prompt text is recorded; checkpoints and
items are identified by hashes.

The predictions were registered before the run and are quoted in the
runner's docstring. Both failed. The record keeps the registered wording
beside the corrected one.

## Why

#754 measured the gate on `recall search` and found it free, because search
never ranks on trust. `suggest` and the briefing do rank on it, through the
ceiling `effective_weight` applies last, so that result did not carry over
and the honest answer for both surfaces was "unmeasured".

The mechanism bounds the answer in advance. The soft clip is the identity
below its knee, so reverting a downgrade changes an item's weight only when
its uncapped accumulation already clears the inferred knee. I called such a
flip lid-biting and counted it beside every difference.

## Results

| Surface | Result |
|---|---|
| suggest, 54 prompts, limit 2 and 5 | 0 of 54 differ (Wilson 0 to 6.6%); 44 fired |
| briefing, 6600 comparisons | 320 differ, 4.85% (Wilson 4.36 to 5.39) |
| briefing items crossing the render cap | 119 across 40 comparisons |
| lid-biting fraction of flips | 41.4% pooled; 76.5% at one day, 3.4% at thirty |

The gate is free on `suggest`: 40 prompts had both a firing suggestion and a
lid-biting flip, and none changed at either limit. Relevance dominates the
product and the one-row-per-session rule absorbs most weight movement.

P1 (every difference traces to a lid-biting flip) failed on one briefing
comparison, and the failure is the finding. `render_plain` stage 1 shortens
oversized items but exempts verbatim ones, so a downgrade to inferred makes
an item truncatable and buys budget; lifting the gate costs a different item
its place. Trust reaches the briefing through a second channel that never
touches `effective_weight`, with the opposite sign. The runner counts that
channel too; with both counted, differences with neither are zero.

P2 (lid-biting flips are a single-digit percent) failed because the horizons
keep items fresh: at one day most flipped items clear the knee, at thirty
days almost none do.

Two scar candidates ride along: the second trust path, and a replay over the
live local store reading as runner nondeterminism until the store is frozen
and fingerprinted. The `inputs` block records both substrate fingerprints.

## Tests

Unit tests for the pure logic, written red first (`ModuleNotFoundError`,
then two `ImportError`s for the helpers the run forced): flip predicate
reuse, uncapped weight equal to `effective_weight` below the knee, lid
biting, truncation exemption, rank and position diffs, cap crossings,
Wilson against known values, and item keys never carrying a raw id.

Determinism: two passes over the frozen snapshot are byte-identical. Store
safety: stat diffs over the local store and the bench stores around the run
are empty. No production code touched; the CI lint and mypy targets pass.
